### PR TITLE
Add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: clojure
+lein: lein2
+script: lein2 midje

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.4.0"]]
-  :profiles {:dev {:dependencies [[midje "1.5.1"]]}
+  :profiles {:dev {:dependencies [[midje "1.5.1"]]
+                   :plugins [[lein-midje "3.1.3"]]}
              :test-reflection [:dev
                                {:global-vars {*warn-on-reflection* true}}]})


### PR DESCRIPTION
This adds config for the popular TravisCI. For travis to work you'll have to enable it in your repo config. I'd also suggest adding a built status badge to the readme.
