### PR TITLE
add a keywords completion source

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject compliment "0.1.0"
+(defproject compliment "0.1.0-SNAPSHOT"
   :description "The Clojure completion library you deserve"
   :url "https://github.com/alexander-yakushev/compliment"
   :license {:name "Eclipse Public License"

--- a/src/compliment/core.clj
+++ b/src/compliment/core.clj
@@ -8,7 +8,8 @@
 through functions defined here."
   (:require (compliment.sources ns-mappings
                                 namespaces-and-classes
-                                class-members))
+                                class-members
+                                keywords))
   (:use [compliment.sources :only [all-sources]]
         [compliment.context :only [cache-context]]
         [clojure.string :only [join]])

--- a/src/compliment/sources/keywords.clj
+++ b/src/compliment/sources/keywords.clj
@@ -1,0 +1,23 @@
+(ns compliment.sources.keywords
+  "Completion for keywords interned globally across the application"
+  (:use [compliment.sources :only [defsource]])
+  (:import java.lang.reflect.Field))
+
+(def ^{:private true}
+  keywords-table
+  (memoize
+   (fn []
+     (let [^Field field (.getDeclaredField clojure.lang.Keyword "table")]
+       (.setAccessible field true)
+       (.get field nil)))))
+
+(defn candidates
+  [prefix _ _]
+  (when (= (first prefix) \:)
+    (for [[kw _] (keywords-table)
+          :when (.startsWith (str kw) (subs prefix 1))]
+      (str ":" kw))))
+
+(defsource ::keywords
+  :candidates #'candidates
+  :doc (constantly nil))


### PR DESCRIPTION
Because keywords are globally interned across the application, I find it useful to have them be completable by my editor's completion middleware. This is mostly a convenience thing I personally missed from SLIME and Common Lisp. If it doesn't make sense for other people, feel free to close this PR. 
