### PR TITLE
Allow completions for vars in . (dot, period) namespace

### DIFF
--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -8,7 +8,7 @@
 (defn var-symbol?
   "Test if prefix resembles a var name."
   [x]
-  (re-matches #"([^\.\/\:][^\.\/]*([^\/\:]*\/[^\.\/]*)?)?" x))
+  (re-matches #"([^\/\:][^\.\/]*([^\/\:]*\/[^\.\/]*)?)?" x))
 
 (defn dash-matches?
   "Tests if prefix partially matches a var name with dashes as


### PR DESCRIPTION
This pull request modifies the regex for recognizing potential var names to allow for namespaces starting with the `.` character. It is quite a popular choice to put utility functions in the `.` namespace so that they are globally available; for examples see [vinyasa][1] and [lein-shorthand][2]. Even though this may not be officially supported, I think it is a good idea to support completions for this namespace. In particular, it is very annoying to not have the standard completions pop-up in Emacs for my utility functions.

It might also be worth making the regex more permissive in other ways, as well, but I didn't want to mess with it too much.

[1]: https://github.com/zcaudate/vinyasa
[2]: https://github.com/palletops/lein-shorthand