### PR TITLE
Fix members-candidates to work with vars on different namespaces

### DIFF
--- a/src/compliment/sources/class_members.clj
+++ b/src/compliment/sources/class_members.clj
@@ -72,12 +72,12 @@
 (defn try-get-object-class
   "Tries to get the type of the object from the context, which the
   member will be applied to. Object should be a Var."
-  [context]
+  [ns context]
   (when (= (:idx (first context)) 0)
     (let [sym (second (:form (first context)))]
       (when (and (symbol? sym)
-                 (= (type (resolve sym)) clojure.lang.Var))
-        (type (deref (resolve sym)))))))
+                 (= (type (ns-resolve ns sym)) clojure.lang.Var))
+        (type (deref (ns-resolve ns sym)))))))
 
 (defn members-candidates
   "Returns a list of Java non-static fields and methods candidates."
@@ -85,7 +85,7 @@
   (when (class-member-symbol? prefix)
     (let [prefix (subs prefix 1)
           inparts? (re-find #"[A-Z]" prefix)
-          klass (try-get-object-class context)]
+          klass (try-get-object-class ns context)]
       (for [[member-name members] (get-all-members ns)
             :when (if inparts?
                     (camel-case-matches? prefix member-name)

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -34,6 +34,18 @@
     (src/members-candidates ".st" *ns* (ctx/parse-context '(__prefix__ a-str)))
     => (strip-tags (just [".startsWith"])))
 
+  (fact "completion should work with vars on different namespaces"
+    (def an-object 1234)
+    (create-ns 'another-ns)
+    (intern 'another-ns 'an-object "foo")
+
+    (let [context (ctx/parse-context '(__prefix__ an-object))]
+      (src/members-candidates ".int" *ns* context)
+      => (strip-tags (just [".intValue"]))
+
+      (src/members-candidates ".toUpper" (find-ns 'another-ns) context)
+      => (strip-tags (just [".toUpperCase"]))))
+
   (fact "class members have docs"
     (src/members-doc ".wait" *ns*) => string?))
 


### PR DESCRIPTION
`members-candidates` does not pass `ns` to `try-get-object-class`, so it does not find vars in different namespaces. Also if there is a var of the same name on the current namespace, it can produce incorrect results.

This patch simply changes `resolve` to `ns-resolve`.