### PR TITLE
Guard against namespace aliases with no namespace

### DIFF
--- a/src/compliment/sources/keywords.clj
+++ b/src/compliment/sources/keywords.clj
@@ -39,12 +39,12 @@
   "Returns a list of alias-qualified double-colon keywords (like ::str/foo),
   where alias has to be registered in the given namespace."
   [prefix ns]
-  (let [[_ alias prefix] (re-matches #"::([^/]+)/(.*)" prefix)
-        alias-ns-name (str (resolve-namespace (symbol alias) ns))]
-    (for [[kw _] (keywords-table)
-          :when (= (namespace kw) alias-ns-name)
-          :when (.startsWith (name kw) prefix)]
-      (tagged-candidate (str "::" alias "/" (name kw))))))
+  (when-let [[_ alias prefix] (re-matches #"::([^/]+)/(.*)" prefix)]
+    (let [alias-ns-name (str (resolve-namespace (symbol alias) ns))]
+      (for [[kw _] (keywords-table)
+            :when (= (namespace kw) alias-ns-name)
+            :when (.startsWith (name kw) prefix)]
+        (tagged-candidate (str "::" alias "/" (name kw)))))))
 
 (defn candidates
   [^String prefix, ns _]

--- a/test/compliment/sources/t_keywords.clj
+++ b/test/compliment/sources/t_keywords.clj
@@ -33,4 +33,8 @@
   (fact "keyword candidates have a special tag"
     (do (str :deprecated)
         (src/candidates ":depr" *ns* nil))
-    => [{:candidate ":deprecated", :type :keyword}]))
+    => [{:candidate ":deprecated", :type :keyword}])
+
+  (fact "namespace aliases without namespace are handled"
+    (do (src/candidates "::/" *ns* nil)
+     => nil)))


### PR DESCRIPTION
When completing keywords, the presence of double colons and a slash
assumed that there was a namespace alias separating the two. We catch
the (infrequent) situation of that not being the case, as this threw
an error when the user was typing

re: https://github.com/alexander-yakushev/compliment/issues/46