### PR TITLE
Correctly resolve namespaces aliased as `user`

### DIFF
--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -51,7 +51,7 @@
   "Tries to resolve a namespace from the given symbol, either from a
   fully qualified name or an alias in the given namespace."
   [sym ns]
-  (or (find-ns sym) ((ns-aliases ns) sym)))
+  (or ((ns-aliases ns) sym) (find-ns sym)))
 
 (defmacro ^{:doc "Defines a memoized function."
             :forms '([name doc-string? [params*] body])}

--- a/test/compliment/t_utils.clj
+++ b/test/compliment/t_utils.clj
@@ -36,4 +36,9 @@
 
 (facts "about classpath"
   (fact "if System/getProperty returns nil, Compliment won't fail"
-    (#'compliment.utils/list-files "" true) => ()))
+        (#'compliment.utils/list-files "" true) => ()))
+
+(facts "about resolving namespaces"
+  (require '[compliment.context :as user])
+  (fact "can resolve a namespace aliased as user"
+    (resolve-namespace 'user *ns*) => (find-ns 'compliment.context)))


### PR DESCRIPTION
https://github.com/alexander-yakushev/compliment/issues/50

look for aliases before fully qualified. really only matters for anything aliased as `user`