### PR TITLE
Run tests against Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 jdk:
   - oraclejdk7
   - oraclejdk8
-  - oraclejdk10
+  - oraclejdk11
 matrix:
   include:
     - script: lein coverage

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -32,11 +32,11 @@
 
   (fact "if context is provided and the class of first arg can be
   resolved, select candidates only for that class (works only for vars)"
-    (strip-tags (src/members-candidates ".st" (-ns) nil))
-    => (just [".start" ".startsWith" ".stop" ".stripTrailingZeros"] :in-any-order)
+    (strip-tags (src/members-candidates ".sta" (-ns) nil))
+    => (just [".start" ".startsWith"] :in-any-order)
 
     (do (def a-str "a string")
-        (strip-tags (src/members-candidates ".st" (-ns) (ctx/parse-context '(__prefix__ a-str)))))
+        (strip-tags (src/members-candidates ".sta" (-ns) (ctx/parse-context '(__prefix__ a-str)))))
     => (just [".startsWith"]))
 
   (fact "completion should work with vars on different namespaces"


### PR DESCRIPTION
Looks like it's failing because of rrb-vector via midge:

```
$ lein deps :why org.clojure/core.rrb-vector
 [midje 1.9.1]
   [mvxcvi/puget 1.0.2]
     [fipp 0.6.10]
       [org.clojure/core.rrb-vector 0.0.11]
```