### PR TITLE
Fix Clojure 1.10 compatibility issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 jdk:
   - oraclejdk7
   - oraclejdk8
-  - oraclejdk10
+  - openjdk10
 matrix:
   include:
     - script: lein coverage

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -164,8 +164,9 @@
         classes (transient [])
         consumer (reify Consumer (accept [_ v] (conj! classes v)))]
     (doseq [mref mrefs
-            :let [mrdr (.invoke open-method mref (object-array 0))]]
-      (-> (.list mrdr) (.forEach consumer))
+            :let [mrdr (.invoke open-method mref (object-array 0))
+                  ^java.util.stream.Stream stream (.list mrdr)]]
+      (.forEach stream consumer)
       (.close mrdr))
 
     (persistent! classes)))


### PR DESCRIPTION
clojure.lang.Reflector is getting more strict, causing it to not
find the call to `.forEach`. By adding a type hint the reflection
goes away.