### PR TITLE
Port the cljs-tooling completion machinery to compliment

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                                   [fudje "0.9.7"]]
                    :plugins [[jonase/eastwood "0.3.5"]
                              [lein-shell "0.5.0"]]
+                   :resource-paths ["test-resources"]
                    :eastwood {:namespaces [:source-paths]}
 
                    :aliases {"test" ["do" ["check"] ["test"]]
@@ -18,5 +19,9 @@
                                          ["shell" "curl" "-F"
                                           "json_file=@target/coverage/coveralls.json"
                                           "https://coveralls.io/api/v1/jobs"]]}}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+             :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]
+                                   [org.clojure/clojurescript "1.10.520" :scope "test"]]}
+             :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]
+                                   [org.clojure/clojurescript "1.10.520" :scope "test"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
+                                   [org.clojure/clojurescript "1.10.520" :scope "test"]]}})

--- a/src/compliment/sources/cljs.cljc
+++ b/src/compliment/sources/cljs.cljc
@@ -1,0 +1,294 @@
+(ns compliment.sources.cljs
+  "Standalone auto-complete library based on cljs analyzer state"
+  (:refer-clojure :exclude [meta])
+  (:require [clojure.pprint :as pprint]
+            [clojure.set :as set]
+            [compliment.sources :refer [defsource]]
+            [compliment.sources.cljs.analysis :as ana]
+            [compliment.sources.ns-mappings :as vars]
+            [compliment.utils :as utils :refer [*extra-metadata*]]))
+
+(defn- candidate-extra
+  [extra-metadata candidate-meta]
+  (when (and (seq extra-metadata) candidate-meta)
+    (let [extra (select-keys candidate-meta extra-metadata)]
+      (cond-> extra
+        (:arglists extra) (update :arglists utils/normalize-arglists)))))
+
+(defn- candidate-data
+  "Returns a map of candidate data for the given arguments."
+  ([candidate ns type]
+   (candidate-data candidate ns type nil nil))
+  ([candidate ns type meta extra-metadata]
+   (merge {:candidate (str candidate)
+           :type type}
+          (when ns {:ns (str ns)})
+          (when (seq extra-metadata)
+            (candidate-extra extra-metadata meta)))))
+
+(defn- var->type
+  "Returns the candidate type corresponding to the given metadata map."
+  [var]
+  (condp #(get %2 %1) var
+    :protocol :protocol-function
+    :fn-var :function
+    :record :record
+    :protocols :type
+    :protocol-symbol :protocol
+    :var))
+
+(def ^:private special-forms
+  '#{& . case* catch def defrecord* deftype* do finally fn* if js* let*
+     letfn* loop* new ns quote recur set! throw try})
+
+(def ^:private special-form-candidates
+  "Candidate data for all special forms."
+  (for [form special-forms]
+    (candidate-data form 'cljs.core :special-form)))
+
+(defn- all-ns-candidates
+  "Returns candidate data for all namespaces in the environment."
+  [env extra-metadata]
+  ;; recent CLJS versions include data about macro namespaces in the
+  ;; compiler env, but we should not include them in completions or pass
+  ;; them to format-ns unless they're actually required (which is handled
+  ;; by macro-ns-candidates below)
+  (for [[ns meta] (ana/all-ns env)]
+    (candidate-data ns nil :namespace meta extra-metadata)))
+
+(defn- ns-candidates
+  "Returns candidate data for all referred namespaces (and their aliases) in context-ns."
+  [env context-ns extra-metadata]
+  (for [[alias ns] (ana/ns-aliases env context-ns)]
+    (candidate-data alias
+                    (when-not (= alias ns) ns)
+                    :namespace
+                    (ana/ns-meta ns)
+                    extra-metadata)))
+
+(defn- macro-ns-candidates
+  "Returns candidate data for all referred macro namespaces (and their aliases) in
+  context-ns."
+  [env context-ns extra-metadata]
+  (for [[alias ns] (ana/macro-ns-aliases env context-ns)]
+    (candidate-data alias
+                    (when-not (= alias ns) ns)
+                    :namespace
+                    ;; given macros are Clojure code we can simply find-ns
+                    ;; the meta should probably be in the compiler env instead
+                    (ana/ns-meta ns)
+                    extra-metadata)))
+
+(defn- referred-var-candidates
+  "Returns candidate data for all referred vars in context-ns."
+  [env context-ns extra-metadata]
+  (for [[refer qualified-sym] (ana/referred-vars env context-ns)
+        :let [ns (namespace qualified-sym)
+              meta (ana/qualified-symbol-meta env qualified-sym)
+              type (var->type meta)]]
+    (candidate-data refer ns type meta extra-metadata)))
+
+(defn- referred-macro-candidates
+  "Returns candidate data for all referred macros in context-ns."
+  [env context-ns extra-metadata]
+  (for [[refer qualified-sym] (ana/referred-macros env context-ns)
+        :let [ns (namespace qualified-sym)
+              meta (ana/macro-meta env qualified-sym)]]
+    (candidate-data refer ns :macro meta extra-metadata)))
+
+(defn- var-candidates
+  [vars extra-metadata]
+  (for [[name meta] vars
+        :let [qualified-name (:name meta)
+              ns (some-> qualified-name namespace)
+              type (var->type meta)]]
+    (candidate-data name ns type meta extra-metadata)))
+
+(defn- ns-var-candidates
+  "Returns candidate data for all vars defined in ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/ns-vars env ns) extra-metadata))
+
+(defn- core-var-candidates
+  "Returns candidate data for all cljs.core vars visible in context-ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/core-vars env ns) extra-metadata))
+
+(defn- macro-candidates
+  [macros extra-metadata]
+  (for [[name var] macros
+        :let [meta (ana/var-meta var)
+              ns (:ns meta)]]
+    (candidate-data name ns :macro meta extra-metadata)))
+
+(defn- core-macro-candidates
+  [env ns extra-metadata]
+  "Returns candidate data for all cljs.core macros visible in ns."
+  (macro-candidates (ana/core-macros env ns) extra-metadata))
+
+(defn- import-candidates
+  "Returns candidate data for all imports in context-ns."
+  [env context-ns]
+  (flatten
+   (for [[import qualified-name] (ana/imports env context-ns)]
+     [(candidate-data import nil :class)
+      (candidate-data qualified-name nil :class)])))
+
+(defn- keyword-candidates
+  "Returns candidate data for all keyword constants in the environment."
+  [env]
+  (map #(candidate-data % nil :keyword) (ana/keyword-constants env)))
+
+(defn- namespaced-keyword-candidates
+  "Returns all namespaced keywords defined in context-ns."
+  [env context-ns]
+  (when context-ns
+    (for [kw (ana/keyword-constants env)
+          :when (= context-ns (utils/as-sym (namespace kw)))]
+      (candidate-data (str "::" (name kw)) context-ns :keyword))))
+
+(defn- referred-namespaced-keyword-candidates
+  "Returns all namespaced keywords referred in context-ns."
+  [env context-ns]
+  (when context-ns
+    (let [aliases (->> (ana/ns-aliases env context-ns)
+                       (filter (fn [[k v]] (not= k v)))
+                       (into {})
+                       (set/map-invert))]
+      (for [kw (ana/keyword-constants env)
+            :let [ns (utils/as-sym (namespace kw))
+                  alias (get aliases ns)]
+            :when alias]
+        (candidate-data (str "::" alias "/" (name kw)) ns :keyword)))))
+
+(defn- unscoped-candidates
+  "Returns all non-namespace-qualified potential candidates in context-ns."
+  [env context-ns extra-metadata]
+  (concat special-form-candidates
+          (all-ns-candidates env extra-metadata)
+          (ns-candidates env context-ns extra-metadata)
+          (macro-ns-candidates env context-ns extra-metadata)
+          (referred-var-candidates env context-ns extra-metadata)
+          (referred-macro-candidates env context-ns extra-metadata)
+          (ns-var-candidates env context-ns extra-metadata)
+          (core-var-candidates env context-ns extra-metadata)
+          (core-macro-candidates env context-ns extra-metadata)
+          (import-candidates env context-ns)
+          (keyword-candidates env)
+          (namespaced-keyword-candidates env context-ns)
+          (referred-namespaced-keyword-candidates env context-ns)))
+
+(defn- prefix-candidate
+  [prefix candidate-data]
+  (let [candidate (:candidate candidate-data)
+        prefixed-candidate (str prefix "/" candidate)]
+    (assoc candidate-data :candidate prefixed-candidate)))
+
+(defn- prefix-candidates
+  [prefix candidates]
+  (map #(prefix-candidate prefix %) candidates))
+
+(defn- ->ns
+  [env symbol-ns context-ns]
+  (if (ana/find-ns env symbol-ns)
+    symbol-ns
+    (ana/ns-alias env symbol-ns context-ns)))
+
+(defn- ->macro-ns
+  [env symbol-ns context-ns]
+  (if (= symbol-ns 'cljs.core)
+    symbol-ns
+    (ana/macro-ns-alias env symbol-ns context-ns)))
+
+(defn- ns-public-var-candidates
+  "Returns candidate data for all public vars defined in ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/public-vars env ns) extra-metadata))
+
+(defn- ns-macro-candidates
+  "Returns candidate data for all macros defined in ns."
+  [env ns extra-metadata]
+  (-> env
+      (ana/public-macros #?(:clj ns :cljs (ana/add-ns-macros ns)))
+      (macro-candidates extra-metadata)))
+
+(defn- scoped-candidates
+  "Returns all candidates for the namespace of sym. Sym must be
+  namespace-qualified. Macro candidates are included if the namespace has its
+  macros required in context-ns."
+  [env sym context-ns extra-metadata]
+  (let [sym-ns (-> sym utils/as-sym utils/namespace-sym)
+        computed-ns (->ns env sym-ns context-ns)
+        macro-ns (->macro-ns env sym-ns context-ns)
+        sym-ns-as-string (str sym-ns)]
+    (mapcat #(prefix-candidates sym-ns-as-string %)
+            [(ns-public-var-candidates env computed-ns extra-metadata)
+             (when macro-ns
+               (ns-macro-candidates env macro-ns extra-metadata))])))
+
+(defn- potential-candidates
+  "Returns all candidates for sym. If sym is namespace-qualified, the candidates
+  for that namespace will be returned (including macros if the namespace has its
+  macros required in context-ns). Otherwise, all non-namespace-qualified
+  candidates for context-ns will be returned."
+  [env context-ns ^String sym extra-metadata]
+  (if (or (= (.indexOf sym "/") -1) (.startsWith sym ":"))
+    (unscoped-candidates env context-ns extra-metadata)
+    (scoped-candidates env sym context-ns extra-metadata)))
+
+(defn- distinct-candidates
+  "Filters candidates to have only one entry for each value of :candidate. If
+  multiple such entries do exist, the first occurrence is used."
+  [candidates]
+  (map first (vals (group-by :candidate candidates))))
+
+(defn- candidate-match?
+  [candidate prefix]
+  (.startsWith ^String (:candidate candidate) prefix))
+
+#?(:cljs
+   (defn- remove-candidate-macros
+     [candidate]
+     (if (= :namespace (:type candidate))
+       (update candidate :candidate (comp str ana/remove-macros))
+       candidate)))
+
+(defn plain-symbol?
+  "Tests if prefix is a symbol with no / (qualified), : (keyword) and
+  . (segmented namespace)."
+  [s]
+  (re-matches #"[^\/\:\.]+" s))
+
+(defn nscl-symbol?
+  "Tests if prefix looks like a namespace or classname."
+  [x]
+  (re-matches #"[^\/\:\.][^\/\:]+" x))
+
+(def ^:dynamic *compiler-env* nil)
+
+(defn candidates
+  "Returns a sequence of candidate data for completions matching the given
+  prefix string and options in the ClojureScript compiler env."
+  [prefix ns context]
+  (let [context-ns (try (ns-name ns) (catch Exception _ nil))]
+    (->> (potential-candidates *compiler-env* context-ns prefix *extra-metadata*)
+         #?(:cljs (map remove-candidate-macros))
+         (distinct-candidates)
+         (filter #(candidate-match? % prefix)))))
+
+(defn doc
+  [s ns-str]
+  (let [ns-str (or ns-str "cljs.core")
+        qualified-sym (symbol ns-str s)]
+    (some->
+     (cond
+       (plain-symbol? s) (or (ana/qualified-symbol-meta *compiler-env* qualified-sym)
+                             (ana/macro-meta *compiler-env* qualified-sym))
+       (nscl-symbol? s) (-> s symbol ana/ns-meta)
+       :else nil)
+     (vars/generate-docstring))))
+
+;; TBD do we want to include it by default?
+;; (defsource ::all
+;;   :candidates #'candidates
+;;   :doc #'doc))

--- a/src/compliment/sources/cljs/analysis.cljc
+++ b/src/compliment/sources/cljs/analysis.cljc
@@ -1,0 +1,249 @@
+(ns compliment.sources.cljs.analysis
+  (:require [clojure.string :as str]
+            [compliment.utils :as utils])
+  (:refer-clojure :exclude [find-ns all-ns ns-aliases]))
+
+(def NSES :cljs.analyzer/namespaces)
+
+(defn all-ns
+  [env]
+  (->> (NSES env)
+       ;; recent CLJS versions include data about macro namespaces in the
+       ;; compiler env, but we should not include them in completions or pass
+       ;; them to format-ns unless they're actually required
+       (into {} (filter (fn [[_ ns]]
+                          (not (and (contains? ns :macros)
+                                    (= 1 (count ns)))))))))
+
+(defn find-ns
+  [env ns]
+  (get (all-ns env) ns))
+
+(defn add-ns-macros
+  "Append $macros to the input symbol"
+  [sym]
+  (some-> sym
+          (str "$macros")
+          symbol))
+
+(defn remove-macros
+  "Remove $macros from the input symbol"
+  [sym]
+  (some-> sym
+          str
+          (str/replace #"\$macros" "")
+          symbol))
+
+;; Code adapted from clojure-complete (http://github.com/ninjudd/clojure-complete)
+
+(defn imports
+  "Returns a map of [import-name] to [ns-qualified-import-name] for all imports
+  in the given namespace."
+  [env ns]
+  (:imports (find-ns env ns)))
+
+(defn ns-aliases
+  "Returns a map {ns-name-or-alias ns-name} for the given namespace."
+  [env ns]
+  (when-let [found (find-ns env ns)]
+    (let [imports (:imports found)]
+      (->> (:requires found)
+           (filter #(not (contains? imports (key %))))
+           (into {})))))
+
+(defn macro-ns-aliases
+  "Returns a map of [macro-ns-name-or-alias] to [macro-ns-name] for the given namespace."
+  [env ns]
+  (:require-macros (find-ns env ns)))
+
+(defn- expand-refer-map
+  [m]
+  (into {} (for [[k v] m] [k (symbol (str v "/" k))])))
+
+(defn referred-vars
+  "Returns a map of [var-name] to [ns-qualified-var-name] for all referred vars
+  in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :uses
+       expand-refer-map))
+
+(defn referred-macros
+  "Returns a map of [macro-name] to [ns-qualified-macro-name] for all referred
+  macros in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :use-macros
+       expand-refer-map))
+
+(defn ns-alias
+  "If sym is an alias to, or the name of, a namespace referred to in ns, returns
+  the name of the namespace; else returns nil."
+  [env sym ns]
+  (get (ns-aliases env ns) (utils/as-sym sym)))
+
+(defn macro-ns-alias
+  "If sym is an alias to, or the name of, a macro namespace referred to in ns,
+  returns the name of the macro namespace; else returns nil."
+  [env sym ns]
+  (get (macro-ns-aliases env ns) (utils/as-sym sym)))
+
+(defn- public?
+  [[_ var]]
+  (not (:private var)))
+
+(defn- named?
+  [[_ var]]
+  (not (:anonymous var)))
+
+(defn- foreign-protocol?
+  [[_ var]]
+  (and (:impls var)
+       (not (:protocol-symbol var))))
+
+(defn- macro?
+  [[_ var]]
+  (:macro (meta var)))
+
+(defn ns-vars
+  "Returns a list of the vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-vars
+  "Returns a list of the public vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? public? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-macros
+  "Given a namespace return all the public var analysis maps. Analagous to
+  clojure.core/ns-publics but returns var analysis maps not vars.
+
+  Inspired by the ns-publics in cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  #?(:clj (when (and ns (clojure.core/find-ns ns))
+            (->> (ns-publics ns)
+                 (filter macro?)
+                 (into {})))
+     :cljs (->> (merge
+                 (get-in env [NSES ns :macros])
+                 (get-in env [NSES ns :defs]))
+                (remove (fn [[k v]] (:private v)))
+                (into {}))))
+
+(defn core-vars
+  "Returns a list of cljs.core vars visible to the ns."
+  [env ns]
+  (let [vars (public-vars env 'cljs.core)
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc vars excludes)))
+
+(defn core-macros
+  "Returns a list of cljs.core macros visible to the ns."
+  [env ns]
+  (let [macros (public-macros env #?(:clj 'cljs.core :cljs 'cljs.core$macros))
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc macros excludes)))
+
+(def ^:private language-keywords
+  #{:require :require-macros :import
+    :refer :refer-macros :include-macros
+    :refer-clojure :exclude
+    :keys :strs :syms
+    :as :or
+    :pre :post
+    :let :when :while
+
+    ;; reader conditionals
+    :clj :cljs :default
+
+    ;; common meta keywords
+    :private :tag :static
+    :doc :author :arglists
+    :added :const
+
+    ;; spec keywords
+    :req :req-un :opt :opt-un
+    :args :ret :fn
+
+    ;; misc
+    :keywordize-keys :else :gen-class})
+
+(defn keyword-constants
+  "Returns a list of both keyword constants in the environment and
+  language specific ones."
+  [env]
+  ;; using namespace for backward compatibility with Clojure 1.8
+  ;; use qualified-keyword? at some point in the future
+  (concat language-keywords (filter namespace (keys (:cljs.analyzer/constant-table env)))))
+
+;; grabbing directly from cljs.analyzer.api
+
+(defn ns-interns-from-env
+  "Given a namespace return all the var analysis maps. Analagous to
+  clojure.core/ns-interns but returns var analysis maps not vars.
+
+  Directly from cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  (merge
+   (get-in env [NSES ns :macros])
+   (get-in env [NSES ns :defs])))
+
+(defn sanitize-ns
+  "Add :ns from :name if missing."
+  [m]
+  (-> m
+      (assoc :ns (or (:ns m) (:name m)))
+      (update :ns utils/namespace-sym)
+      (update :name utils/name-sym)))
+
+(defn ns-obj?
+  "Return true if n is a namespace object"
+  [ns]
+  (instance? #?(:clj clojure.lang.Namespace
+                :cljs cljs.core/Namespace)
+             ns))
+
+(defn var-meta
+  "Return meta for the var, we wrap it in order to support both JVM and
+  self-host."
+  [var]
+  (cond-> {}
+    (map? var) (merge var)
+    (var? var) (-> (merge (meta var))
+                   (update :ns #(cond-> % (ns-obj? %) ns-name)))
+    true sanitize-ns
+    #?@(:cljs [true (-> (update :ns remove-macros)
+                        (update :name remove-macros))])))
+
+(defn qualified-symbol-meta
+  "Given a namespace-qualified var name, gets the analyzer metadata for
+  that var."
+  [env sym]
+  {:pre [(symbol? sym)]}
+  (let [ns (find-ns env (utils/namespace-sym sym))]
+    (some-> (:defs ns)
+            (get (utils/name-sym sym))
+            var-meta)))
+
+(defn ns-meta
+  [ns]
+  {:pre [(symbol? ns)]}
+  (meta (clojure.core/find-ns ns)))
+
+(defn macro-meta
+  [env qualified-sym]
+  #?(:clj (var-meta (find-var qualified-sym))
+     :cljs (let [referred-ns (symbol (namespace qualified-sym))]
+             (-> env
+                 (ns-interns-from-env (add-ns-macros referred-ns))
+                 (get refer)
+                 var-meta))))

--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -2,7 +2,7 @@
   "Completion for vars and classes in the current namespace."
   (:require [compliment.sources :refer [defsource]]
             [compliment.utils :refer [fuzzy-matches? resolve-namespace
-                                      *extra-metadata*]])
+                                      normalize-arglists *extra-metadata*]])
   (:import java.io.StringWriter))
 
 (defn var-symbol?
@@ -97,8 +97,8 @@
                                arglists :function
                                :else :var)
                    :ns (str (or (:ns var-meta) ns))}
-            (and arglists(:arglists *extra-metadata*))
-            (assoc :arglists (apply list (map pr-str arglists)))
+            (and arglists (:arglists *extra-metadata*))
+            (assoc :arglists (normalize-arglists arglists))
 
             (and doc (:doc *extra-metadata*))
             (assoc :doc (generate-docstring var-meta))))))))

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -217,3 +217,43 @@
                            (.endsWith file ".jar") (.endsWith file ".class")))]
         (if (.startsWith file File/separator)
           (.substring file 1) file)))))
+
+
+(defn as-sym [x]
+  (if x (symbol x)))
+
+(defn namespace-sym
+  "Return the namespace of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [ns (and sym (namespace sym))]
+    (as-sym ns)
+    sym))
+
+(defn name-sym
+  "Return the name of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [n (and sym (name sym))]
+    (as-sym n)
+    sym))
+
+(defn unquote-first
+  "Handles some weird double-quoting in the analyzer"
+  [form]
+  (if (= (first form) 'quote)
+    (first (rest form))
+    form))
+
+(defn normalize-arglists
+  "Take metadata arglists and normalize them.
+
+  Normalization being mainly removing the quote of the first element and
+  wrapping in a list."
+  [arglists]
+  (some->> arglists
+           (unquote-first)
+           (map pr-str)
+           (apply list)))

--- a/test-resources/compliment/cljs/env.cljc
+++ b/test-resources/compliment/cljs/env.cljc
@@ -1,0 +1,23 @@
+(ns compliment.cljs.env
+  (:require [cljs.env :as env]
+            #?@(:clj [[cljs.analyzer.api :as ana]
+                      [cljs.build.api :as build]
+                      [cljs.compiler.api :as comp]
+                      [clojure.java.io :as io]])))
+
+(def test-namespace "compliment/test_ns.cljs" )
+
+(defn create-test-env []
+  #?(:clj
+     (let [opts (build/add-implicit-options {:cache-analysis true, :output-dir "target/out"})
+           env (env/default-compiler-env opts)]
+       (comp/with-core-cljs env opts
+         (fn []
+           (let [r (io/resource test-namespace)]
+             (assert r (str "Cannot find " test-namespace " is your lein profile add test-resources correctly?"))
+             (ana/analyze-file env r opts))))
+       @env)
+
+     :cljs
+     (do (repl/eval '(require (quote cljs-tooling.test-ns)) 'cljs-tooling.test-env)
+         @env/*compiler*)))

--- a/test-resources/compliment/test_macros.clj
+++ b/test-resources/compliment/test_macros.clj
@@ -1,0 +1,11 @@
+(ns ^{:doc "A test macro namespace"} compliment.test-macros)
+
+(defmacro my-add
+  "This is an addition macro"
+  [a b]
+  `(+ ~a ~b))
+
+(defmacro my-sub
+  "This is a subtraction macro"
+  [a b]
+  `(- ~a ~b))

--- a/test-resources/compliment/test_ns.cljs
+++ b/test-resources/compliment/test_ns.cljs
@@ -1,0 +1,22 @@
+(ns ^{:doc "A test namespace"} compliment.test-ns
+  (:refer-clojure :exclude [unchecked-byte while])
+  (:require [clojure.string]
+            [compliment.test-ns-dep :as test-dep :refer [foo-in-dep]])
+  (:require-macros [compliment.test-macros :as test-macros :refer [my-add]])
+  (:import [goog.ui IdGenerator]))
+
+(defrecord TestRecord [a b c])
+
+(def x ::some-namespaced-keyword)
+
+(defn issue-28
+  []
+  (str "https://github.com/clojure-emacs/cljs-tooling/issues/28"))
+
+(defn test-public-fn
+  []
+  42)
+
+(defn- test-private-fn
+  []
+  (inc (test-public-fn)))

--- a/test-resources/compliment/test_ns_dep.cljs
+++ b/test-resources/compliment/test_ns_dep.cljs
@@ -1,0 +1,5 @@
+(ns ^{:doc "Dependency of test-ns namespace"} compliment.test-ns-dep)
+
+(defn foo-in-dep [foo] :bar)
+
+(def x ::dep-namespaced-keyword)

--- a/test/compliment/sources/t_cljs.cljc
+++ b/test/compliment/sources/t_cljs.cljc
@@ -1,0 +1,297 @@
+(ns compliment.sources.t-cljs
+  (:require [clojure.set :as set]
+            [clojure.string :as s]
+            [clojure.test :as test #?(:clj :refer :cljs :refer-macros) [deftest is testing use-fixtures]]
+            [clojure.tools.reader.edn :as edn]
+            [clojure.walk :as walk]
+            [compliment.cljs.env :as cljs-env]
+            [compliment.sources.cljs :as cljs-sources]
+            [compliment.utils :refer [*extra-metadata*]]))
+
+(use-fixtures :once
+  (fn [f]
+    (binding [cljs-sources/*compiler-env* (cljs-env/create-test-env)]
+      (f))))
+
+(defn completions
+  [prefix & [ns]]
+  (cljs-sources/candidates prefix (some-> ns find-ns) nil))
+
+(defn set=
+  [coll1 coll2 & colls]
+  (apply = (set coll1) (set coll2) (map set colls)))
+
+(deftest sanity
+  (testing "Nothing returned for non-existent prefix"
+    (is (= '()
+           (completions "abcdefghijk")
+           (completions "abcdefghijk" 'compliment.test-ns))))
+
+  (testing "cljs.core candidates returned for new namespaces"
+    (is (= (completions "")
+           (completions "" 'abcdefghijk))))
+
+  (let [all-candidates (completions "" 'compliment.test-ns)]
+    (testing "All candidates have a string for :candidate"
+      (is (every? (comp string? :candidate) all-candidates)))
+
+    (testing "All candidates that should have an :ns, do"
+      (let [filter-fn #(not (#{:import :keyword :namespace :class} (:type %)))
+            filtered-candidates (filter filter-fn all-candidates)]
+        (is (every? :ns filtered-candidates))))
+
+    (testing "All candidates have a valid :type"
+      (let [valid-types #{:function
+                          :class
+                          :keyword
+                          :macro
+                          :namespace
+                          :protocol
+                          :protocol-function
+                          :record
+                          :special-form
+                          :type
+                          :var}]
+        (is (every? (comp valid-types :type) all-candidates))))))
+
+(deftest special-form-completions
+  (testing "Special form"
+    (is (= '({:candidate "throw" :ns "cljs.core" :type :special-form})
+           (completions "thr")))
+
+    (is (set= '({:candidate "def" :ns "cljs.core" :type :special-form}
+                {:candidate "do" :ns "cljs.core" :type :special-form}
+                {:candidate "defrecord*" :ns "cljs.core" :type :special-form}
+                {:candidate "deftype*" :ns "cljs.core" :type :special-form})
+              (->> (completions "d")
+                   (filter #(= :special-form (:type %))))))))
+
+(deftest namespace-completions
+  (testing "Namespace"
+    (is (set= '({:candidate "compliment.test-ns" :type :namespace}
+                {:candidate "compliment.test-ns-dep" :type :namespace})
+              (completions "compliment.t"))))
+
+  (testing "Macro Namespace"
+    (is (set= '({:candidate "compliment.test-ns" :type :namespace}
+                {:candidate "compliment.test-ns-dep" :type :namespace}
+                {:candidate "compliment.test-macros" :type :namespace})
+              (completions "compliment.t" 'compliment.test-ns))))
+
+  (testing "Namespace alias"
+    (is (= '()
+           (completions "test-d")
+           (completions "test-d" 'cljs.user)))
+    (is (= '({:candidate "test-dep" :ns "compliment.test-ns-dep" :type :namespace})
+           (completions "test-d" 'compliment.test-ns)))))
+
+(deftest macro-namespace-completions
+  (testing "Macro namespace"
+    (is (= '()
+           (completions "compliment.test-macros")
+           (completions "compliment.test-macros" 'cljs.user)))
+    (is (= '({:candidate "compliment.test-macros" :type :namespace})
+           (completions "compliment.test-m" 'compliment.test-ns))))
+
+  (testing "Macro namespace alias"
+    (is (= '()
+           (completions "test-m")))
+    (is (= '({:candidate "test-macros" :ns "compliment.test-macros" :type :namespace})
+           (completions "test-m" 'compliment.test-ns)))))
+
+(deftest fn-completions
+  (testing "cljs.core fn"
+    (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :type :function}
+                {:candidate "unchecked-add-int" :ns "cljs.core" :type :function})
+              (completions "unchecked-a")
+              (completions "unchecked-a" 'cljs.user)))
+    (is (set= '({:candidate "cljs.core/unchecked-add" :ns "cljs.core" :type :function}
+                {:candidate "cljs.core/unchecked-add-int" :ns "cljs.core" :type :function})
+              (completions "cljs.core/unchecked-a")
+              (completions "cljs.core/unchecked-a" 'cljs.user))))
+
+  (testing "Excluded cljs.core fn"
+    (is (= '()
+           (completions "unchecked-b" 'compliment.test-ns)))
+    (is (= '({:candidate "cljs.core/unchecked-byte" :ns "cljs.core" :type :function})
+           (completions "cljs.core/unchecked-b" 'compliment.test-ns))))
+
+  (testing "Namespace-qualified fn"
+    (is (= '({:candidate "compliment.test-ns/issue-28" :ns "compliment.test-ns" :type :function})
+           (completions "compliment.test-ns/iss")
+           (completions "compliment.test-ns/iss" 'cljs.user)
+           (completions "compliment.test-ns/iss" 'compliment.test-ns))))
+
+  (testing "Referred fn"
+    (is (= '()
+           (completions "bla")
+           (completions "bla" 'compliment.test-ns)))
+    (is (= '({:candidate "foo-in-dep" :ns "compliment.test-ns-dep" :type :function})
+           (completions "foo" 'compliment.test-ns))))
+
+  (testing "Local fn"
+    (is (= '({:candidate "test-public-fn" :ns "compliment.test-ns" :type :function})
+           (completions "test-pu" 'compliment.test-ns))))
+
+  (testing "Private fn"
+    (is (= '()
+           (completions "test-pri")
+           (completions "test-pri" 'cljs.user)))
+    (is (= '({:candidate "test-private-fn" :ns "compliment.test-ns" :type :function})
+           (completions "test-pri" 'compliment.test-ns))))
+
+  (testing "Fn shadowing macro with same name"
+    (is (= '({:candidate "identical?" :ns "cljs.core" :type :function})
+           (completions "identical?")))))
+
+(deftest macro-completions
+  (testing "cljs.core macro"
+    (is (set= '({:candidate "cond->" :ns "cljs.core" :type :macro}
+                {:candidate "cond->>" :ns "cljs.core" :type :macro})
+              (completions "cond-")
+              (completions "cond-" 'compliment.test-ns)))
+    (is (set= '({:candidate "cljs.core/cond->" :ns "cljs.core" :type :macro}
+                {:candidate "cljs.core/cond->>" :ns "cljs.core" :type :macro})
+              (completions "cljs.core/cond-")
+              (completions "cljs.core/cond-" 'compliment.test-ns))))
+
+  (testing "Excluded cljs.core macro"
+    (is (= '()
+           (completions "whil" 'compliment.test-ns)))
+    (is (= '({:candidate "cljs.core/while" :ns "cljs.core" :type :macro})
+           (completions "cljs.core/whil" 'compliment.test-ns))))
+
+  (testing "Namespace-qualified macro"
+    (is (= '()
+           (completions "compliment.test-macros/non-existent")
+           (completions "compliment.test-macros/non-existent" 'cljs.user)))
+    (is (set= '({:candidate "compliment.test-macros/my-add" :ns "compliment.test-macros" :type :macro}
+                {:candidate "compliment.test-macros/my-sub" :ns "compliment.test-macros" :type :macro})
+              (completions "compliment.test-macros/my-" 'compliment.test-ns))))
+
+  (testing "Referred macro"
+    (is (= '()
+           (completions "non-existent")
+           (completions "non-existent" 'compliment.test-ns)))
+    ;; only my-add cause it is the only one referred
+    (is (= '({:candidate "my-add" :ns "compliment.test-macros" :type :macro})
+           (completions "my-" 'compliment.test-ns)))))
+
+(deftest import-completions
+  (testing "Import"
+    (is (= '()
+           (completions "IdGen")
+           (completions "IdGen" 'cljs.user)))
+    (is (= '({:candidate "IdGenerator" :type :class})
+           (completions "IdGen" 'compliment.test-ns))))
+
+  (testing "Namespace-qualified import"
+    (is (= '()
+           (completions "goog.ui.IdGen")
+           (completions "goog.ui.IdGen" 'cljs.user)))
+    (is (= '({:candidate "goog.ui.IdGenerator" :type :class})
+           (completions "goog.ui.IdGen" 'compliment.test-ns)))))
+
+(deftest keyword-completions
+  (testing "Keyword"
+    (is (empty? (set/difference (set '({:candidate ":refer-macros" :type :keyword}
+                                       {:candidate ":require-macros" :type :keyword}))
+                                (set (completions ":re")))) "the completion should include ClojureScript-specific keywords."))
+
+  (testing "Local namespaced keyword"
+    (is (= '({:candidate "::some-namespaced-keyword" :ns "compliment.test-ns" :type :keyword})
+           (completions "::so" 'compliment.test-ns)))
+
+    (is (= '()
+           (completions "::i" 'compliment.test-ns))))
+
+  (testing "Referred namespaced keyword"
+    (is (= '()
+           (completions "::test-dep/f" 'compliment.test-ns)))
+
+    (is (= '({:candidate "::test-dep/dep-namespaced-keyword" :ns "compliment.test-ns-dep" :type :keyword})
+           (completions "::test-dep/d" 'compliment.test-ns)))))
+
+(deftest protocol-completions
+  (testing "Protocol"
+    (is (set= '({:candidate "IIndexed" :ns "cljs.core" :type :protocol}
+                {:candidate "IIterable" :ns "cljs.core" :type :protocol})
+              (completions "II"))))
+
+  (testing "Protocol fn"
+    (is (set= '({:candidate "-with-meta" :ns "cljs.core" :type :protocol-function}
+                {:candidate "-write" :ns "cljs.core" :type :protocol-function})
+              (completions "-w")))))
+
+(deftest record-completions
+  (testing "Record"
+    (is (= '({:candidate "TestRecord" :ns "compliment.test-ns" :type :record})
+           (completions "Te" 'compliment.test-ns)))))
+
+(deftest type-completions
+  (testing "Type"
+    (is (set= '({:candidate "ES6Iterator" :ns "cljs.core" :type :type}
+                {:candidate "ES6IteratorSeq" :ns "cljs.core" :type :type})
+              (completions "ES6I")))))
+
+(deftest extra-metadata
+  (testing "Extra metadata: namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (set= '({:candidate "compliment.test-ns" :doc "A test namespace" :type :namespace}
+                  {:candidate "compliment.test-ns-dep" :doc "Dependency of test-ns namespace" :type :namespace})
+                (completions "compliment.test-")))))
+
+  (testing "Extra metadata: aliased namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (= '({:candidate "test-dep" :doc "Dependency of test-ns namespace" :ns "compliment.test-ns-dep" :type :namespace})
+             (completions "test-d" 'compliment.test-ns)))))
+
+  (testing "Extra metadata: macro namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (= '({:candidate "compliment.test-macros" :doc "A test macro namespace" :type :namespace})
+             (completions "compliment.test-m" 'compliment.test-ns)))))
+
+  (testing "Extra metadata: normal var :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :arglists ("[]" "[x]" "[x y]" "[x y & more]") :type :function}
+                  {:candidate "unchecked-add-int" :ns "cljs.core" :arglists ("[]" "[x]" "[x y]" "[x y & more]") :type :function})
+                (completions "unchecked-a" 'cljs.user)))))
+
+  (testing "Extra metadata: normal var :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :doc "Returns the sum of nums. (+) returns 0." :type :function}
+                  {:candidate "unchecked-add-int" :ns "cljs.core" :doc "Returns the sum of nums. (+) returns 0." :type :function})
+                (completions "unchecked-a" 'cljs.user)))))
+
+  (testing "Extra metadata: macro :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "defprotocol" :ns "cljs.core" :arglists ("[psym & doc+methods]") :type :macro})
+             (completions "defproto" 'cljs.user)))))
+
+  (testing "Extra metadata: referred var :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "foo-in-dep" :ns "compliment.test-ns-dep" :arglists ("[foo]") :type :function})
+             (completions "foo" 'compliment.test-ns)))))
+
+  (testing "Extra metadata: referred macro :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "my-add" :ns "compliment.test-macros" :arglists ("[a b]") :type :macro})
+             (completions "my-a" 'compliment.test-ns))))))
+
+(deftest predicates
+  (testing "The plain-symbol? predicate"
+    (is (cljs-sources/plain-symbol? "foo") "should detect a \"plain\" symbol")
+    (is (not (cljs-sources/plain-symbol? "foo.bar")) "should NOT match a namespace")
+    (is (not (cljs-sources/plain-symbol? ":foo")) "should NOT match a keyword")
+    (is (not (cljs-sources/plain-symbol? "::foo/bar")) "should NOT match a qualified keyword")
+    (is (not (cljs-sources/plain-symbol? "foo/bar")) "should NOT match a qualified symbol")))
+
+(deftest docstring-generation
+  (testing "symbol docstring"
+    (is (string? (cljs-sources/doc "map" nil)) "should return the map docstring, defaulting to the cljs.core namespace")
+    (is (string? (cljs-sources/doc "map" "cljs.core")) "should return the map docstring")
+    (is (string? (cljs-sources/doc "my-add" "compliment.test-macros"))))
+
+  (testing "namespace docstring"
+    (is (= "\n  A test macro namespace\n" (cljs-sources/doc "compliment.test-macros" nil)))
+    (is (= "\n  A test namespace\n" (cljs-sources/doc "compliment.test-ns" nil)))))

--- a/test/compliment/sources/t_keywords.clj
+++ b/test/compliment/sources/t_keywords.clj
@@ -33,9 +33,9 @@
     => (just ["::src"]))
 
   (fact "keyword candidates have a special tag"
-    (do (str :deprecated)
-        (src/candidates ":depr" *ns* nil))
-    => (just [{:candidate ":deprecated", :type :keyword}]))
+    (do (str :my-deprecated)
+        (src/candidates ":my" *ns* nil))
+    => (just [{:candidate ":my-deprecated" :type :keyword}]))
 
   (fact "namespace aliases without namespace are handled"
     (src/candidates "::/" *ns* nil)

--- a/test/compliment/t_core.clj
+++ b/test/compliment/t_core.clj
@@ -25,6 +25,10 @@
     (strip-tags (core/completions "core/doc" {:ns (find-ns 'compliment.t-core)}))
     => (just ["core/documentation"]))
 
+  (fact "ClojureScript default candidates should come from cljs.core"
+    (core/completions "" {:sources [:compliment.sources.cljs/clojurescript]})
+    => (checker (fn [cs] (every? #(= "cljs.core" (:ns %)) cs))))
+
   (fact "in case of non-existing namespace doesn't fail"
     (core/completions "redu" {:ns nil}) => anything
     (core/completions "n-m" {:ns 'foo.bar.baz}) => anything)


### PR DESCRIPTION
This PR shows what CLJS completions look like.

The code is ported from `cljs-tooling` - what is used by Cider for ClojureScript completions.

The goal here is to end up with the same public api and behavior. Probably some
of the Compliment options would not apply in which case, please, advice :smile:

I am always open to tweaks of any sort, just send any feedback over.