### PR TITLE
Add the defsource for cljs completions

### DIFF
--- a/src/compliment/core.clj
+++ b/src/compliment/core.clj
@@ -12,7 +12,8 @@
                                 keywords
                                 special-forms
                                 local-bindings
-                                resources)
+                                resources
+                                cljs)
             [compliment.sources :refer [all-sources]]
             [compliment.context :refer [cache-context]]
             [compliment.utils :refer [*extra-metadata*]]

--- a/src/compliment/sources/cljs.cljc
+++ b/src/compliment/sources/cljs.cljc
@@ -288,7 +288,6 @@
        :else nil)
      (vars/generate-docstring))))
 
-;; TBD do we want to include it by default?
-;; (defsource ::all
-;;   :candidates #'candidates
-;;   :doc #'doc))
+(defsource ::cljs-completions
+  :candidates #'candidates
+  :doc #'doc)


### PR DESCRIPTION
It was a TODO of the previous PR.

---
Note that this is a breaking change because it modifies the previous set of default sources that `compliment` had hardcoded, which was Clojure only.

---

I wonder whether there should be any default at all - we could let the client decide (see also #70).