### PR TITLE
[Fix #68] Add source vars for language-specific completions

### DIFF
--- a/src/compliment/core.clj
+++ b/src/compliment/core.clj
@@ -106,3 +106,17 @@
             docstr)
           (interpose "\n\n")
           join))))
+
+(def clj-sources
+  "Source keywords for Clojure completions."
+  [:compliment.sources.ns-mappings/ns-mappings
+   :compliment.sources.namespaces-and-classes/namespaces-and-classes
+   :compliment.sources.class-members/static-members
+   :compliment.sources.keywords/keywords
+   :compliment.sources.special-forms/literals
+   :compliment.sources.local-bindings/local-bindings
+   :compliment.sources.resources/resources])
+
+(def cljs-sources
+  "Source keywords for ClojureScript completions."
+  [:compliment.sources.cljs/cljs-completions])


### PR DESCRIPTION
This patch introduces two vars necessary for the `:sources` option that would
allow us to distinguish between Clojure vs ClojureScript candidates.

If #67 goes in, they will be inevitably mixed up otherwise.