### PR TITLE
WIP - Incorporate suitable's JS completions

### DIFF
--- a/src/compliment/sources/cljs.cljc
+++ b/src/compliment/sources/cljs.cljc
@@ -267,7 +267,10 @@
 
 (defn candidates
   "Returns a sequence of candidate data for completions matching the given
-  prefix string and options in the ClojureScript compiler env."
+  prefix string and options.
+
+  It requires the compliment.sources.cljs/*compiler-env* var to be dynamically
+  bound to the ClojureScript compiler env."
   [prefix ns context]
   (let [context-ns (try (ns-name ns) (catch Exception _ nil))]
     (->> (potential-candidates *compiler-env* context-ns prefix *extra-metadata*)

--- a/src/compliment/sources/cljs.cljc
+++ b/src/compliment/sources/cljs.cljc
@@ -1,8 +1,7 @@
 (ns compliment.sources.cljs
   "Standalone auto-complete library based on cljs analyzer state"
   (:refer-clojure :exclude [meta])
-  (:require [clojure.pprint :as pprint]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [compliment.sources :refer [defsource]]
             [compliment.sources.cljs.analysis :as ana]
             [compliment.sources.ns-mappings :as vars]

--- a/src/compliment/sources/cljs/ast.cljc
+++ b/src/compliment/sources/cljs/ast.cljc
@@ -1,0 +1,52 @@
+(ns compliment.sources.cljs.ast
+  (:require [clojure.pprint :refer [pprint *print-right-margin*]]
+            [clojure.zip :as z])
+  #?(:clj (:import [clojure.lang IPersistentList IPersistentMap IPersistentVector ISeq])))
+
+(def V #?(:clj IPersistentVector
+          :cljs PersistentVector))
+(def M #?(:clj IPersistentMap
+          :cljs PersistentArrayMap))
+(def L #?(:clj IPersistentList
+          :cljs List))
+(def S ISeq)
+
+;; Thx @ Alex Miller! http://www.ibm.com/developerworks/library/j-treevisit/
+(defmulti tree-branch? type)
+(defmethod tree-branch? :default [_] false)
+(defmethod tree-branch? V [v] (not-empty v))
+(defmethod tree-branch? M [m] (not-empty m))
+(defmethod tree-branch? L [l] true)
+(defmethod tree-branch? S [s] true)
+(prefer-method tree-branch? L S)
+
+(defmulti tree-children type)
+(defmethod tree-children V [v] v)
+(defmethod tree-children M [m] (->> m seq (apply concat)))
+(defmethod tree-children L [l] l)
+(defmethod tree-children S [s] s)
+(prefer-method tree-children L S)
+
+(defmulti tree-make-node (fn [node children] (type node)))
+(defmethod tree-make-node V [v children]
+  (vec children))
+(defmethod tree-make-node M [m children]
+  (apply hash-map children))
+(defmethod tree-make-node L [_ children]
+  children)
+(defmethod tree-make-node S [node children]
+  (apply list children))
+(prefer-method tree-make-node L S)
+
+(defn tree-zipper [node]
+  (z/zipper tree-branch? tree-children tree-make-node node))
+
+(defn print-tree
+  "for debugging"
+  [node]
+  (let [all (take-while (complement z/end?) (iterate z/next (tree-zipper node)))]
+    (binding [*print-right-margin* 20]
+      (pprint
+       (->> all
+            (map z/node) (zipmap (range))
+            sort)))))

--- a/src/compliment/sources/cljs/js_introspection.cljs
+++ b/src/compliment/sources/cljs/js_introspection.cljs
@@ -1,0 +1,57 @@
+(ns compliment.source.cljs.js-introspection
+  (:require [clojure.string :refer [starts-with?]]
+            [goog.object :refer [get] :rename {get oget}]))
+
+(def own-property-descriptors
+  (if (js-in "getOwnPropertyDescriptors" js/Object)
+    ;; ES 6+ version
+    (fn [obj] (js/Object.getOwnPropertyDescriptors obj))
+    ;; ES 5.1 version
+    (fn [obj] (->> obj
+                   js/Object.getOwnPropertyNames
+                   (map (fn [key] [key (js/Object.getOwnPropertyDescriptor obj key)]))
+                   (into {})
+                   clj->js))))
+
+(defn properties-by-prototype
+  ""
+  [obj]
+  (loop [obj obj protos []]
+    (if obj
+      (recur
+       (js/Object.getPrototypeOf obj)
+       (conj protos {:obj obj :props (own-property-descriptors obj)}))
+      protos)))
+
+(defn property-names-and-types
+  ([js-obj] (property-names-and-types js-obj nil))
+  ([js-obj prefix]
+   (let [seen (transient #{})]
+     (for [[i {:keys [obj props]}] (map-indexed vector (properties-by-prototype js-obj))
+           key (js-keys props)
+           :when (and (not (get seen key))
+                      (or (empty? prefix)
+                          (starts-with? key prefix)))]
+       (let [prop (oget props key)]
+         (conj! seen key)
+         {:name key
+          :hierarchy i
+          :type (try
+                  (if-let [value (or (oget prop "value")
+                                     (-> prop (oget "get")
+                                         (apply [])))]
+                    (if (fn? value) "function" "var")
+                    "var")
+                  (catch js/Error e "var"))})))))
+
+(comment
+  (require '[cljs.pprint :refer [pprint]])
+  ;; (-> js/console property-names-and-types pprint)
+  (-> js/document.body property-names-and-types pprint)
+
+  (let [obj (new (fn [x] (this-as this (goog.object/set this "foo" 23))))]
+    (pprint (property-names-and-types obj)))
+
+  (oget js/console "log")
+  (-> js/console property-names-and-types pprint)
+  (-> js/window property-names-and-types pprint))

--- a/src/compliment/sources/cljs_js.cljc
+++ b/src/compliment/sources/cljs_js.cljc
@@ -1,0 +1,196 @@
+(ns compliment.sources.cljs-js
+  (:require [clojure.pprint :refer [cl-format]]
+            [clojure.string :as str]
+            [clojure.zip :as zip]
+            [compliment.sources :refer [defsource]]
+            [compliment.sources.cljs.ast :as ast])
+  (:import java.io.StringReader))
+
+(def debug? false)
+
+(defn js-properties-of-object
+  "Returns the properties of the object we get by evaluating `:expr`
+  filtered by all those that start with `prefix`."
+  ([cljs-eval-fn ns expr]
+   (js-properties-of-object cljs-eval-fn ns expr nil))
+  ([cljs-eval-fn ns expr prefix]
+   (try
+     ;; :Not using a single expressiont / eval call here like
+     ;; (do (require ...) (runtime ...))
+     ;; to avoid
+     ;; Compile Warning:  Use of undeclared Var
+     ;;   compliment.sources.cljs.js-introspection/property-names-and-types
+     (let [template "(compliment.sources.cljs.js-introspection/property-names-and-types ~A ~S)"
+           code (cl-format nil template expr prefix)]
+       (cljs-eval-fn ns "(require 'compliment.sources.cljs.js-introspection)")
+       (cljs-eval-fn ns code))
+     (catch #?(:clj Exception :cljs js/Error) e {:error e}))))
+
+(defn find-prefix
+  [form]
+  "Tree search for the symbol '__prefix. Returns a zipper."
+  (loop [node (ast/tree-zipper form)]
+    (if (= '__prefix__ (zip/node node))
+      node
+      (when-not (zip/end? node)
+        (recur (zip/next node))))))
+
+(defn thread-form?
+  "True if form looks like the name of a thread macro."
+  [form]
+  (->> form
+       str
+       (re-find #"->")
+       nil?
+       not))
+
+(defn doto-form? [form]
+  (= form 'doto))
+
+(defn expr-for-parent-obj
+  "Given the prefix and the context of a completion request, will try to
+  find an expression that evaluates to the object being accessed."
+  [prefix context]
+  (when-let [form (if (string? context)
+                    (try
+                      (with-in-str context (read *in* nil nil))
+                      (catch Exception _e
+                        (when debug?
+                          (binding [*out* *err*]
+                            (cl-format true "Error reading context: ~s" context)))))
+                    context)]
+    (let [prefix-zipper (find-prefix form)
+          left-sibling (zip/left prefix-zipper)
+          first? (nil? left-sibling)
+          first-sibling (and (not first?) (some-> prefix-zipper zip/leftmost zip/node))
+          first-sibling-in-parent (some-> prefix-zipper zip/up zip/leftmost zip/node)
+          threaded? (if first? (thread-form? first-sibling-in-parent) (thread-form? first-sibling) )
+          doto? (if first? (doto-form? first-sibling-in-parent) (doto-form? first-sibling))
+          dot-fn? (str/starts-with? prefix ".")]
+
+      (letfn [(with-type [type maybe-expr]
+                (when maybe-expr
+                  {:type type
+                   :expr maybe-expr}))]
+        (cond
+          (nil? prefix-zipper) nil
+
+          ;; is it a threading macro?
+          threaded?
+          (with-type :-> (if first?
+                           ;; parent is the thread
+                           (-> prefix-zipper zip/up zip/lefts str)
+                           ;; thread on same level
+                           (-> prefix-zipper zip/lefts str)))
+
+          doto?
+          (with-type :doto (if first?
+                             ;; parent is the thread
+                             (-> prefix-zipper zip/up zip/leftmost zip/right zip/node str)
+                             ;; thread on same level
+                             (-> prefix-zipper zip/leftmost zip/right zip/node str)))
+
+          ;; a .. form: if __prefix__ is a prop deeper than one level we need the ..
+          ;; expr up to that point. If just the object that is accessed is left of
+          ;; prefix, we can take that verbatim.
+          ;; (.. js/console log) => js/console
+          ;; (.. js/console -memory -jsHeapSizeLimit) => (.. js/console -memory)
+          (and first-sibling (#{"." ".."} (str first-sibling)) left-sibling)
+          (with-type :.. (let [lefts (-> prefix-zipper zip/lefts)]
+                           (if (<= (count lefts) 2)
+                             (str (last lefts))
+                             (str lefts))))
+
+          ;; (.. js/window -console (log "foo")) => (.. js/window -console)
+          (and first? (-> prefix-zipper zip/up zip/leftmost zip/node str (= "..")))
+          (with-type :.. (let [lefts (-> prefix-zipper zip/up zip/lefts)]
+                           (if (<= (count lefts) 2)
+                             (str (last lefts))
+                             (str lefts))))
+
+          ;; simple (.foo bar)
+          (and first? dot-fn?)
+          (with-type :. (some-> prefix-zipper zip/right zip/node str)))))))
+
+(def ^:private global-expr-re #"^js/((?:[^\.]+\.)*)([^\.]*)$")
+(def ^:private dot-dash-prefix-re #"^\.-?")
+(def ^:private dash-prefix-re #"^-")
+(def ^:private dot-prefix-re #"\.")
+
+(defn- prepare-eval-data
+  "Build a map of data that we can use to fetch the properties from an
+  object that is the result of some `:expr` when evaled and that is used
+  to convert those properties into candidates for completion."
+  [prefix context]
+  ;; js-prefix is a massaged prefix, base on Cljs interop syntax
+  (if (str/starts-with? prefix "js/")
+    ;; js-prefix could be a global like js/console or global/property like js/console.log
+    (let [[_ dotted-expr js-prefix] (re-matches global-expr-re prefix)
+          expr-parts (keep not-empty (str/split dotted-expr dot-prefix-re))
+          ;; builds an expr like
+          ;; "(this-as this (.. this -window))" for prefix = "js/window.console"
+          ;; or "(this-as this this)" for prefix = "js/window"
+          expr (cl-format nil "(this-as this ~[this~:;(.. this ~{-~A~^ ~})~])"
+                          (count expr-parts) expr-parts)]
+      ;; expr-parts
+      {:js-prefix js-prefix
+       :prepend-to-candidate (str "js/" dotted-expr)
+       :vars-have-dashes? false
+       :expr expr
+       :type :global})
+
+    ;; otherwise js-prefix is just a property name embedded in some expr
+    (let [{:keys [type] :as expr-and-type} (expr-for-parent-obj prefix context)]
+      (assoc expr-and-type
+             :prepend-to-candidate (if (str/starts-with? prefix ".") "." "")
+             :js-prefix (case type
+                          :.. (str/replace prefix dash-prefix-re "")
+                          (str/replace prefix dot-dash-prefix-re ""))
+             :vars-have-dashes? true))))
+
+(def ^:dynamic *cljs-eval-fn* nil)
+
+(defn candidates
+  "Returns a sequence of candidate data for JavaScript completions
+  matching the given prefix string, ns and context.
+
+  It requires the compliment.sources.cljs-js/*cljs-eval-fn* var to be
+  dynamically bound to a function that given a namespace (as string) and
+  cljs code (string) will evaluate it and return the value as a clojure
+  object.
+
+  See `suitable.middleware/cljs-dynamic-completion-handler` for
+  how to setup an eval function with nREPL.
+
+  Currently unsupported options that compliment implements
+  are :extra-metadata :sort-order and :plain-candidates."
+  [prefix ns context]
+  ;; Given some context (the toplevel form that has changed) and the prefix
+  ;; string that represents the last typed input, we try to find out if the
+  ;; context/prefix are object access (property access or method call). If so,
+  ;; we try to extract a form that we can evaluate to get the object that is
+  ;; accessed. If we get the object, we enumerate it's properties and methods
+  ;; and generate a list of matching completions for those.
+  (let [{:keys [js-prefix prepend-to-candidate vars-have-dashes? expr type] :as eval-data}
+        (prepare-eval-data prefix context)
+        global? (#{:global} type)]
+    (when debug?
+      (binding [*out* *err*]
+        (println "Eval data:" eval-data)))
+    (when-let [{error :error properties :value}
+               (and expr (js-properties-of-object *cljs-eval-fn* ns expr js-prefix))]
+      (if error
+        (when debug?
+          (binding [*out* *err*]
+            (println "Error in JS completions:" error)))
+        (for [{:keys [name type]} properties
+              :let [maybe-dash (if (and vars-have-dashes? (= "var" type)) "-" "")
+                    candidate (str prepend-to-candidate maybe-dash name)]
+              :when (str/starts-with? candidate prefix)]
+          {:type type :candidate candidate :ns (if global? "js" expr)})))))
+
+(def doc (constantly nil))
+
+(defsource ::js-interop
+  :candidates #'candidates
+  :doc #'doc)

--- a/test/compliment/sources/t_cljs_js.clj
+++ b/test/compliment/sources/t_cljs_js.clj
@@ -1,0 +1,186 @@
+(ns compliment.sources.t-cljs-js
+  (:require [clojure.pprint :refer [cl-format]]
+            [clojure.string :refer [starts-with?]]
+            [clojure.test :as t :refer [deftest is run-tests]]
+            [compliment.sources.cljs-js :as cljs-js]))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; helpers
+
+(defn fake-cljs-eval-fn
+  [expected-expression expected-prefix properties]
+  (fn [ns code]
+    (when-let [[_ expr prefix]
+               (re-matches
+                #"^\(compliment.sources.cljs.js-introspection/property-names-and-types (.*) \"(.*)\"\)"
+                code)]
+      (if (and (= expr expected-expression)
+               (= prefix expected-prefix))
+        {:error nil
+         :value properties}
+        (is false (cl-format nil "Expected expr / prefix~% ~S / ~S~% passed to fake-js-props-fn does not match actual expr / prefix~% ~S / ~S"
+                             expected-expression expected-prefix
+                             expr prefix))))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; expr-for-parent-obj
+
+(deftest expr-for-parent-obj
+  (let [state {:special-namespaces ["js"]}
+        tests [ ;; should not trigger object completion
+               {:desc "no object in sight"
+                :symbol-and-context    [".log" "(__prefix__)"]
+                :expected nil}
+
+               {:desc "Normal object/class name is typed, not method or special name."
+                :symbol-and-context    ["bar" "(.log __prefix__)"]
+                :expected nil}
+
+               ;; should trigger object completion
+               {:desc ". method"
+                :symbol-and-context    [".log" "(__prefix__ js/console)"]
+                :expected {:type :. :expr "js/console"}}
+
+               {:desc ". method nested"
+                :symbol-and-context    [".log" "(__prefix__ (.-console js/window) \"foo\")"]
+                :expected {:type :. :expr "(.-console js/window)"}}
+
+               {:desc ".- prop"
+                :symbol-and-context    [".-memory" "(__prefix__ js/console)"]
+                :expected {:type :. :expr "js/console"}}
+
+               {:desc ".- prop nested"
+                :symbol-and-context    [".-memory" "(__prefix__ (.-console js/window) \"foo\")"]
+                :expected {:type :. :expr "(.-console js/window)"}}
+
+               {:desc ".. method"
+                :symbol-and-context    ["log" "(.. js/console __prefix__)"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc ".. method nested"
+                :symbol-and-context    ["log" "(.. js/console (__prefix__ \"foo\"))"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc ".. method chained"
+                :symbol-and-context    ["log" "(.. js/window -console __prefix__)"]
+                :expected {:type :.. :expr "(.. js/window -console)"}}
+
+               {:desc ".. method chained and nested"
+                :symbol-and-context    ["log" "(.. js/window -console (__prefix__ \"foo\"))"]
+                :expected {:type :.. :expr "(.. js/window -console)"}}
+
+               {:desc ".. prop"
+                :symbol-and-context    ["-memory" "(.. js/console __prefix__)"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc "->"
+                :symbol-and-context    [".log" "(-> js/console __prefix__)"]
+                :expected {:type :-> :expr "(-> js/console)"}}
+
+               {:desc "-> (.)"
+                :symbol-and-context    [".log" "(-> js/console (__prefix__ \"foo\"))"]
+                :expected {:type :-> :expr "(-> js/console)"}}
+
+               {:desc "-> chained"
+                :symbol-and-context    [".log" "(-> js/window .-console __prefix__)"]
+                :expected {:type :-> :expr "(-> js/window .-console)"}}
+
+               {:desc "-> (.)"
+                :symbol-and-context    [".log" "(-> js/window .-console (__prefix__ \"foo\"))"]
+                :expected {:type :-> :expr "(-> js/window .-console)"}}
+
+               {:desc "doto"
+                :symbol-and-context    [".log" "(doto (. js/window -console) __prefix__)"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "doto (.)"
+                :symbol-and-context    [".log" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "doto (.)"
+                :symbol-and-context    ["js/cons" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "no prefix"
+                :symbol-and-context    ["xx" "(foo bar (baz))"]
+                :expected nil}]]
+
+    (doseq [{[symbol context] :symbol-and-context :keys [expected desc]} tests]
+      (is (= expected (cljs-js/expr-for-parent-obj symbol context)) desc))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; JS candidates
+
+(deftest global
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this this)" "c"
+                                                      [{:name "console" :hierarchy 1 :type "var"}
+                                                       {:name "confirm" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/console" :ns "js" :type "var"}
+            {:candidate "js/confirm" :ns "js" :type "function"}]
+           (cljs-js/candidates  "js/c" "cljs.user" "")))))
+
+(deftest global-prop
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this (.. this -console))" "lo"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/console.log" :ns "js" :type "function"}]
+           (cljs-js/candidates "js/console.lo" "cljs.user" "js/console")))))
+
+(deftest global-prop-2
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this (.. this -window -console))" "lo"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/window.console.log" :ns "js" :type "function"}]
+           (cljs-js/candidates "js/window.console.lo" "cljs.user" "js/console")))))
+
+(deftest simple
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/console" "l"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate ".log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)")))
+    (is (= [{:candidate "log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates "l" "cljs.user" "(. js/console __prefix__)")))
+    ;; note: we're testing context with a form here
+    (is (= [{:candidate "log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates "l" "cljs.user" '(.. js/console (__prefix__ "foo")))))))
+
+(deftest dotdot-completion
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/foo" "ba"
+                                                      [{:name "bar" :hierarchy 1 :type "var"}
+                                                       {:name "baz" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "-bar" :ns "js/foo" :type "var"}]
+           (cljs-js/candidates "-ba" "cljs.user" "(.. js/foo __prefix__)")))
+    (is (= [{:candidate "baz" :ns "js/foo" :type "function"}]
+           (cljs-js/candidates "ba" "cljs.user" "(.. js/foo __prefix__)")))))
+
+(deftest dotdot-completion-chained+nested
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(.. js/foo zork)" "ba"
+                                                      [{:name "bar" :hierarchy 1 :type "var"}
+                                                       {:name "baz" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "-bar" :ns "(.. js/foo zork)" :type "var"}]
+           (cljs-js/candidates "-ba" "cljs.user" "(.. js/foo zork (__prefix__ \"foo\"))")))
+    (is (= [{:candidate "baz" :ns "(.. js/foo zork)" :type "function"}]
+           (cljs-js/candidates "ba" "cljs.user" "(.. js/foo zork (__prefix__ \"foo\"))")))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+(comment
+
+  (run-tests 'compliment.sources.t-cljs-js)
+
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/console" "l"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)"))
+
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this this)" "c"
+                                                      [{:name "console" :hierarchy 1 :type "var"}])]
+    (cljs-js/candidates "js/c" "cljs.user" :context ""))
+
+  (cljs-js/expr-for-parent-obj "foo" nil "(__prefix__ foo)")
+  (cljs-js/expr-for-parent-obj ".l" "cljs.user" "(__prefix__ js/console)")
+
+  (with-redefs [cljs-js/js-properties-of-object (fn [obj-expr msg] [])]
+    (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)" nil))
+  )


### PR DESCRIPTION
This patch moves the logic we need from suitable in order to have completions for Cljs/Js interop.

It exposes the necessary dynamic vars for setting up `*compliment.sources.cljs-js/*cljs-eval-fn**`.

It also registers a new source with name `:compliment.sources.cljs-js/js-interop`.

__This is a breaking change because it modifies the previous set of default sources that compliment had hardcoded, which was Clojure only.__

Back in WIP mode, more questions need to be answered.