### PR TITLE
Remove reflection warnings

### DIFF
--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -4,6 +4,10 @@
            (java.util.jar JarFile JarEntry)
            java.util.function.Consumer))
 
+;; Disable reflection warnings in this file because we must use reflection to
+;; support both JDK8 and JDK9+.
+(set! *warn-on-reflection* false)
+
 (def ^:dynamic *extra-metadata*
   "Signals to downstream sources which additional information about completion
   candidates they should attach . Should be a set of keywords."


### PR DESCRIPTION
It removes the following annoying reflection warnings while using the cider-repl:

```
Reflection warning, compliment/utils.clj:160:15 - reference to field findAll on java.lang.Object can't be resolved.
Reflection warning, compliment/utils.clj:168:51 - reference to field list on java.lang.Object can't be resolved.
Reflection warning, compliment/utils.clj:170:7 - reference to field close on java.lang.Object can't be resolved.
Reflection warning, compliment/utils.clj:168:51 - reference to field list on java.lang.Object can't be resolved.
Reflection warning, compliment/utils.clj:170:7 - reference to field close on java.lang.Object can't be resolved.
```

all test pass with JDK8 and JDK9+
