### PR TITLE
Fix completion of Java packages/classes on Windows.

### DIFF
--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -195,7 +195,8 @@
                             (not (.contains file "$")))]
              (.. (if (.startsWith file File/separator)
                    (.substring file 1) file)
-                 (replace ".class" "") (replace File/separator ".")))
+                 (replace ".class" "") (replace File/separator ".")
+                 (replace "/" ".")))
            (group-by #(subs % 0 (max (.indexOf ^String % ".") 0)))))))
 
 (defn namespaces-on-classpath


### PR DESCRIPTION
Since file pathes inside jar files contain '/' instead
of `File/separator', '/' also should be replaced with '.'
Before this fix, completion of java packages such as
java.util.*, java.nio.* does not work, it works now.