### PR TITLE
Add `classes-on-classpath-test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,22 @@ jobs:
             - ~/.m2
           key: project-{{ checksum "project.clj" }}
 
+  test-jdk17:
+    working_directory: ~/project
+    docker:
+      - image: circleci/clojure:openjdk-17-lein-2.9.5-buster
+    steps:
+      - checkout
+      - restore_cache:
+          key: project-{{ checksum "project.clj" }}
+      - run: lein with-profile +1.8 test
+      - run: lein with-profile +1.9 test
+      - run: lein with-profile +1.10 test
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: project-{{ checksum "project.clj" }}
+
   lint-and-coverage:
     working_directory: ~/project
     docker:
@@ -54,4 +70,5 @@ workflows:
     jobs:
       - test-jdk8
       - test-jdk11
+      - test-jdk17
       - lint-and-coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - run: lein with-profile +1.8 test
       - run: lein with-profile +1.9 test
       - run: lein with-profile +1.10 test
+      - run: lein with-profile +1.10 eastwood
       - save_cache:
           paths:
             - ~/.m2
@@ -27,6 +28,7 @@ jobs:
       - run: lein with-profile +1.8 test
       - run: lein with-profile +1.9 test
       - run: lein with-profile +1.10 test
+      - run: lein with-profile +1.10 eastwood
       - save_cache:
           paths:
             - ~/.m2
@@ -43,12 +45,13 @@ jobs:
       - run: lein with-profile +1.8 test
       - run: lein with-profile +1.9 test
       - run: lein with-profile +1.10 test
+      - run: lein with-profile +1.10 eastwood
       - save_cache:
           paths:
             - ~/.m2
           key: project-{{ checksum "project.clj" }}
 
-  lint-and-coverage:
+  coverage:
     working_directory: ~/project
     docker:
       - image: clojure:openjdk-8-lein-2.9.0
@@ -56,7 +59,6 @@ jobs:
       - checkout
       - restore_cache:
           key: project-{{ checksum "project.clj" }}
-      - run: lein eastwood
       - run: CIRCLECI=true lein with-profile +1.10 coverage
       - store_artifacts:
           path: target/coverage
@@ -71,4 +73,4 @@ workflows:
       - test-jdk8
       - test-jdk11
       - test-jdk17
-      - lint-and-coverage
+      - coverage

--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,14 @@
                                   [criterium "0.4.4"]
                                   [cloverage "1.0.13"]
                                   [fudje "0.9.7"]]
-                   :plugins [[jonase/eastwood "0.3.5"]
+                   :plugins [[jonase/eastwood "1.2.3"]
                              [lein-shell "0.5.0"]]
-                   :eastwood {:namespaces [:source-paths]}
+                   :eastwood {:ignored-faults {:reflection {compliment.utils true}
+                                               :bad-arglists {compliment.sources.t-local-bindings true}
+                                               :def-in-def {compliment.sources.t-class-members true
+                                                            compliment.sources.t-ns-mappings true
+                                                            compliment.t-core true
+                                                            compliment.sources.t-local-bindings true}}}
 
                    :aliases {"test" ["do" ["check"] ["test"]]
                              "bench" ["run" "-m" "compliment.t-benchmark" "true"]

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -13,7 +13,7 @@
   candidates they should attach . Should be a set of keywords."
   nil)
 
-(def resource-separator
+(def ^String resource-separator
   "The path separator used within resources and .jar files.
 
 Note that should always have the same value, regardless of OS."

--- a/test/compliment/sources/t_resources.clj
+++ b/test/compliment/sources/t_resources.clj
@@ -20,6 +20,6 @@
 
   (fact "there are docs for resources too"
     (src/doc "META-INF/maven/compliment/compliment/pom.properties" *ns*)
-    => (checker #(.startsWith % "File type: application/unknown, size:"))
+    => (checker #(.startsWith ^String % "File type: application/unknown, size:"))
 
     (src/doc "not-a-resource" *ns*) => nil))

--- a/test/compliment/t_utils.clj
+++ b/test/compliment/t_utils.clj
@@ -42,3 +42,13 @@
   (require '[compliment.context :as user])
   (fact "can resolve a namespace aliased as user"
     (resolve-namespace 'user *ns*) => (find-ns 'compliment.context)))
+
+(deftest classes-on-classpath-test
+  (let [all-classes (->> (classes-on-classpath)
+                         (vals)
+                         (reduce into)
+                         (set))]
+    (is (< 3000 (count all-classes)))
+    (is (contains? all-classes "java.lang.Thread"))
+    (is (contains? all-classes "java.io.File"))
+    (is (contains? all-classes "java.nio.channels.FileChannel"))))


### PR DESCRIPTION
I was unsure about whether `classes-on-classpath` was comprehensive so I coded a test for it, particularly for a few cases that I particuarly cared about.

While I was there I also added a few CI improvements. Commits:

* `Add classes-on-classpath-test`
* Add JDK17 to the test matrix
* CI: use Eastwood within each JDK
  * Eastwood, being runtime-powered, can provide additional insights this way.
* Upgrade Eastwood
* Use Clojure 1.10.3

I have a green build in my account https://app.circleci.com/pipelines/github/reducecombine/compliment

Cheers - V