### PR TITLE
Also offer completions for (var-) quoted symbols

### DIFF
--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -74,7 +74,9 @@
   either the scope (if prefix is scoped), `ns` arg or the namespace
   extracted from context if inside `ns` declaration."
   [^String prefix, ns context]
-  (let [prefix (-> prefix
+  (let [quoted-prefix (or (re-find #"^#'" prefix)
+                          (re-find #"^'" prefix))
+        prefix (-> prefix
                    ;; consider var-quote and quote to express the same as the non-quoted equivalent,
                    ;; since that is more useful than offering no completions:
                    (string/replace-first #"^#'" "")
@@ -98,7 +100,7 @@
                         (.getName ^Package pkg))}
 
             (cond-> {:candidate (if scope
-                                  (str scope-name "/" var-name)
+                                  (str quoted-prefix scope-name "/" var-name)
                                   var-name)
                      :type (cond (:macro var-meta) :macro
                                  arglists :function

--- a/test/compliment/t_core.clj
+++ b/test/compliment/t_core.clj
@@ -13,6 +13,12 @@
     (strip-tags (core/completions "redu"))
     => (contains ["reduce" "reduce-kv" "reductions"] :gaps-ok)
 
+    (strip-tags (core/completions "'redu"))
+    => (contains ["reduce" "reduce-kv" "reductions"] :gaps-ok)
+
+    (strip-tags (core/completions "#'redu"))
+    => (contains ["reduce" "reduce-kv" "reductions"] :gaps-ok)
+
     (strip-tags (core/completions "fac" {:ns (find-ns 'fudje.sweet)}))
     => (just ["fact" "facts"] :in-any-order)
 
@@ -22,7 +28,19 @@
     (strip-tags (core/completions "compliment.core/co"))
     => (just ["compliment.core/completions"])
 
+    (strip-tags (core/completions "'compliment.core/co"))
+    => (just ["compliment.core/completions"])
+
+    (strip-tags (core/completions "#'compliment.core/co"))
+    => (just ["compliment.core/completions"])
+
     (strip-tags (core/completions "core/doc" {:ns (find-ns 'compliment.t-core)}))
+    => (just ["core/documentation"])
+
+    (strip-tags (core/completions "'core/doc" {:ns (find-ns 'compliment.t-core)}))
+    => (just ["core/documentation"])
+
+    (strip-tags (core/completions "#'core/doc" {:ns (find-ns 'compliment.t-core)}))
     => (just ["core/documentation"]))
 
   (fact "in case of non-existing namespace doesn't fail"

--- a/test/compliment/t_core.clj
+++ b/test/compliment/t_core.clj
@@ -29,19 +29,19 @@
     => (just ["compliment.core/completions"])
 
     (strip-tags (core/completions "'compliment.core/co"))
-    => (just ["compliment.core/completions"])
+    => (just ["'compliment.core/completions"])
 
     (strip-tags (core/completions "#'compliment.core/co"))
-    => (just ["compliment.core/completions"])
+    => (just ["#'compliment.core/completions"])
 
     (strip-tags (core/completions "core/doc" {:ns (find-ns 'compliment.t-core)}))
     => (just ["core/documentation"])
 
     (strip-tags (core/completions "'core/doc" {:ns (find-ns 'compliment.t-core)}))
-    => (just ["core/documentation"])
+    => (just ["'core/documentation"])
 
     (strip-tags (core/completions "#'core/doc" {:ns (find-ns 'compliment.t-core)}))
-    => (just ["core/documentation"]))
+    => (just ["#'core/documentation"]))
 
   (fact "in case of non-existing namespace doesn't fail"
     (core/completions "redu" {:ns nil}) => anything


### PR DESCRIPTION
Hi Alex,

it seemed to me that completions could be offered for quoted or var-quoted symbols.

Examples included as deftests.

The proposed solution is not particularly fancy, it might not be even be located in the best place but it might be at least a good conversation starter!

Build is green in my account:

<img width="580" alt="image" src="https://user-images.githubusercontent.com/1162994/156968632-ce816c6b-a231-494d-b9f9-feafc9d54054.png">

Best wishes 🇺🇦