### PR TITLE
Fix for namespaced keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ### master (unreleased)
 
+- [#82](https://github.com/alexander-yakushev/compliment/pull/82): Offer completions for quoted var-quoted symbols.
 - [#83](https://github.com/alexander-yakushev/compliment/pull/83): Complete
   local bindings declared in map destructuring with namespaced keywords.
 - [#83](https://github.com/alexander-yakushev/compliment/pull/83): Fix completion
   of local bindings when a context contain namespaced keywords.
+- [#84](https://github.com/alexander-yakushev/compliment/pull/84): Enable
+  locals completion for `defmethod` form.
 
 ### 0.3.12 (2021-10-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### master (unreleased)
 
-- [#82](https://github.com/alexander-yakushev/compliment/pull/82): Offer completions for quoted var-quoted symbols.
-- [#84](https://github.com/alexander-yakushev/compliment/pull/84): Enable
-  locals completion for `defmethod` form.
+- [#83](https://github.com/alexander-yakushev/compliment/pull/83): Complete
+  local bindings declared in map destructuring with namespaced keywords.
+- [#83](https://github.com/alexander-yakushev/compliment/pull/83): Fix completion
+  of local bindings when a context contain namespaced keywords.
 
 ### 0.3.12 (2021-10-21)
 

--- a/src/compliment/context.clj
+++ b/src/compliment/context.clj
@@ -15,11 +15,14 @@
 
 (defn- try-read-replacing-maps [s]
   (try (binding [*read-eval* false]
-         (-> s
-             (str/replace "{" "(compliment-hashmap ")
-             (str/replace "}" ")")
-             read-string
-             restore-map-literals))
+         (let [ns-aliases (ns-aliases *ns*)]
+           (-> s
+               (str/replace "{" "(compliment-hashmap ")
+               (str/replace "}" ")")
+               (str/replace #"::([-\w]+)/" (fn [[_ kw-ns]]
+                                             (str ":" (get ns-aliases (symbol kw-ns) kw-ns) "/")))
+               read-string
+               restore-map-literals)))
        (catch Exception ex)))
 
 (defn- dumb-read-form

--- a/test/compliment/sources/t_local_bindings.clj
+++ b/test/compliment/sources/t_local_bindings.clj
@@ -87,10 +87,14 @@
                                          '(let [foo 42,
                                                 [bar baz] lst
                                                 {a :a, {b :b :as c} :b, [d] :d} m
-                                                {:keys [key1 key2] :strs [key3]} m2
+                                                {:keys [key1 key2] :strs [key3] :syms [key4]} m2
+                                                {:keys [:a/key5 :b/key6 ::src/key7 ::src/key8]} m3
+                                                {:c/keys [key9 key10] :c/syms [key11]} m4
+                                                {::src/keys [key12 key13] ::src/syms [key14]} m5
                                                 [_ rec {urs :ive :as total}] val]
                                             __prefix__))))
-    => (just ["foo" "bar" "baz" "a" "b" "c" "d" "key1" "key2" "key3"
+    => (just ["foo" "bar" "baz" "a" "b" "c" "d" "key1" "key2" "key3" "key4" "key5"
+              "key6" "key7" "key8" "key9" "key10" "key11" "key12" "key13" "key14"
               "rec" "urs" "total"] :in-any-order))
 
   (defmacro ^{:completion/locals :doseq} like-doseq [& _])

--- a/test/compliment/t_context.clj
+++ b/test/compliment/t_context.clj
@@ -12,6 +12,14 @@
     (is (= '(__prefix__ foo [bar] :baz "with strings")
            (#'ctx/safe-read-context-string "(__prefix__ foo [bar] :baz \"with strings\")"))))
 
+  (testing "aliased namespace keyword is replaced to non-aliased namespace keyword"
+    (is (= '(__prefix__ foo [bar] :my-ns/baz "with strings")
+           (#'ctx/safe-read-context-string "(__prefix__ foo [bar] ::my-ns/baz \"with strings\")")))
+    (is (= '(__prefix__ foo [bar] :my.full.namespace/baz "with strings")
+           (do
+             (alias 'my-ns (create-ns 'my.full.namespace))
+             (#'ctx/safe-read-context-string "(__prefix__ foo [bar] ::my-ns/baz \"with strings\")")))))
+
   (testing "maps with odd number of elements are also handled"
     (is (= '{:foo bar, __prefix__ nil}
            (#'ctx/safe-read-context-string "{:foo bar __prefix__}")))))


### PR DESCRIPTION
First of all, thank you for developing and maintaining 'compliment'.
I found problems related to namespaced keywords:
- `compliment.context/try-read-replacing-maps` return `nil` if aliased namespace keywords(e.g. `::my-ns/keyword`) are contained in context string. (`read-str` try to resolve the alias)
  I changed `try-read-replacing-maps` to replace aliased namespace keyword to namespaced keyword(e.g. `:my-ns/keyword`) to avoid the problem.
- `compliment.sources.local-bindings/parse-binding` ignore variables that destructuring the map with namespaced keywords:
  ```clj
  (require '[instaparse.gll :as gll])
  (let [#_..., {::gll/keys [start-index end-index]} (meta x)])
  ```
  I changed `parse-binding` to handle namespaced keywords.