### PR TITLE
Slightly optimize `compliment.sources.namespaces-and-classes/candidates`

### DIFF
--- a/src/compliment/sources/namespaces_and_classes.clj
+++ b/src/compliment/sources/namespaces_and_classes.clj
@@ -77,40 +77,41 @@
   (when (nscl-symbol? prefix)
     (let [has-dot (> (.indexOf prefix ".") -1)
           import-ctx (analyze-import-context context)]
-      ((comp distinct concat)
-       (for [ns-str (concat (map (comp name ns-name) (all-ns))
-                            (map name (keys (ns-aliases ns))))
-             :when (nscl-matches? prefix ns-str)]
-         {:candidate ns-str, :type :namespace})
-       (for [class-str (imported-classes ns)
-             :when (nscl-matches? prefix class-str)]
-         {:candidate class-str, :type :class})
-       (cond (= import-ctx :root) (get-all-full-names prefix)
-             import-ctx (get-classes-by-package-name prefix import-ctx))
-       ;; For capitalized prefixes, try to complete class FQN from a short name.
-       (when (and (Character/isUpperCase (.charAt prefix 0))
-                  (not import-ctx))
-         (get-all-full-names prefix))
-       ;; If prefix doesn't contain a period, using fuziness produces too many
-       ;; irrelevant candidates.
-       (for [^String ns-str (utils/namespaces-on-classpath)
-             :when (if has-dot
-                     (nscl-matches? prefix ns-str)
-                     (.startsWith ns-str prefix))]
-         {:candidate ns-str, :type :namespace})
-       ;; Fuzziness is too slow for all classes, so only startsWith. Also, if no
-       ;; period in prefix, only complete root package names to maintain good
-       ;; performance and not produce too many candidates.
-       (let [all-classes (utils/classes-on-classpath)]
-         (if (or has-dot (contains? all-classes prefix))
-           (for [[root-pkg classes] all-classes
-                 :when (.startsWith prefix root-pkg)
-                 ^String cl-str classes
-                 :when (.startsWith cl-str prefix)]
-             {:candidate cl-str, :type :class})
-           (for [[^String root-pkg _] all-classes
-                 :when (.startsWith root-pkg prefix)]
-             {:candidate (str root-pkg "."), :type :class})))))))
+      (into []
+            (comp cat (distinct))
+            [(for [ns-str (concat (map (comp name ns-name) (all-ns))
+                                  (map name (keys (ns-aliases ns))))
+                   :when (nscl-matches? prefix ns-str)]
+               {:candidate ns-str, :type :namespace})
+             (for [class-str (imported-classes ns)
+                   :when (nscl-matches? prefix class-str)]
+               {:candidate class-str, :type :class})
+             (cond (= import-ctx :root) (get-all-full-names prefix)
+                   import-ctx (get-classes-by-package-name prefix import-ctx))
+             ;; For capitalized prefixes, try to complete class FQN from a short name.
+             (when (and (Character/isUpperCase (.charAt prefix 0))
+                        (not import-ctx))
+               (get-all-full-names prefix))
+             ;; If prefix doesn't contain a period, using fuziness produces too many
+             ;; irrelevant candidates.
+             (for [^String ns-str (utils/namespaces-on-classpath)
+                   :when (if has-dot
+                           (nscl-matches? prefix ns-str)
+                           (.startsWith ns-str prefix))]
+               {:candidate ns-str, :type :namespace})
+             ;; Fuzziness is too slow for all classes, so only startsWith. Also, if no
+             ;; period in prefix, only complete root package names to maintain good
+             ;; performance and not produce too many candidates.
+             (let [all-classes (utils/classes-on-classpath)]
+               (if (or has-dot (contains? all-classes prefix))
+                 (for [[root-pkg classes] all-classes
+                       :when (.startsWith prefix root-pkg)
+                       ^String cl-str classes
+                       :when (.startsWith cl-str prefix)]
+                   {:candidate cl-str, :type :class})
+                 (for [[^String root-pkg _] all-classes
+                       :when (.startsWith root-pkg prefix)]
+                   {:candidate (str root-pkg "."), :type :class})))]))))
 
 (defn doc [ns-or-class-str curr-ns]
   (when (nscl-symbol? ns-or-class-str)


### PR DESCRIPTION
Changes `(comp distinct concat)` -> `(into [] (comp cat (distinct)) [,,,])` which should be slightly faster and take less memory.

Cheers - V