### PR TITLE
Suggest private vars and add :deprecated key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Extend completion and getting docs for symbol-strings with leading literals.
+- Find private vars when using var quote literal.
 
 ### 0.3.15 (2023-06-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Extend completion and getting docs for symbol-strings with leading literals.
 - Find private vars when using var quote literal.
+- Add `:deprecated` key to vars and functions.
 
 ### 0.3.15 (2023-06-22)
 

--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -85,7 +85,7 @@
                    :else (ns-map ns))]
         (for [[var-sym var] vars
               :let [var-name (name var-sym)
-                    {:keys [arglists doc private] :as var-meta} (meta var)]
+                    {:keys [arglists doc private deprecated] :as var-meta} (meta var)]
               :when (and (dash-matches? prefix var-name)
                          (not (:completion/hidden var-meta)))]
           (if (= (type var) Class)
@@ -102,6 +102,7 @@
                                  arglists :function
                                  :else :var)
                      :private (boolean private)
+                     :deprecated (boolean deprecated)
                      :ns (str (or (:ns var-meta) ns))}
               (and arglists (:arglists *extra-metadata*))
               (assoc :arglists (apply list (map pr-str arglists)))

--- a/test/compliment/sources/t_ns_mappings.clj
+++ b/test/compliment/sources/t_ns_mappings.clj
@@ -40,16 +40,16 @@
 (deftest vars-completion-test
   (fact "unqualified vars are looked up in the given namespace"
     (src/candidates "redu" (-ns) nil)
-    => (contains #{{:candidate "reduce", :type :function, :ns "clojure.core", :private false}
-                   {:candidate "reductions", :type :function, :ns "clojure.core", :private false}
-                   {:candidate "reduce-kv", :type :function, :ns "clojure.core", :private false}}
+    => (contains #{{:candidate "reduce", :type :function, :ns "clojure.core", :private false, :deprecated false}
+                   {:candidate "reductions", :type :function, :ns "clojure.core", :private false, :deprecated false}
+                   {:candidate "reduce-kv", :type :function, :ns "clojure.core", :private false, :deprecated false}}
                  :gaps-ok)
 
     (strip-tags (src/candidates "re-ma" (-ns) nil))
     => (just ["re-matches" "re-matcher" "ref-max-history"] :in-any-order)
 
     (src/candidates "bindi" (-ns) nil)
-    => [{:candidate "binding", :type :macro, :ns "clojure.core", :private false}])
+    => [{:candidate "binding", :type :macro, :ns "clojure.core", :private false, :deprecated false}])
 
   (fact "imported classes are looked up in the given namespace"
     (src/candidates "Runt" (-ns) nil)
@@ -134,7 +134,8 @@
   (fact "extra metadata can be requested from this completion source"
     (binding [*extra-metadata* #{:doc :arglists}]
       (doall (src/candidates "freq" (-ns) nil)))
-    => [{:candidate "frequencies", :type :function, :ns "clojure.core", :private false, :arglists ["[coll]"]
+    => [{:candidate "frequencies", :type :function, :ns "clojure.core", :private false, :deprecated false
+         :arglists ["[coll]"]
          :doc (clojure.string/join
                (System/lineSeparator)
                ["clojure.core/frequencies" "([coll])"

--- a/test/compliment/t_core.clj
+++ b/test/compliment/t_core.clj
@@ -75,9 +75,9 @@
     => (contains ["map-indexed" "map?" "mapcat" "mapv"] :gaps-ok)
 
     (core/completions "remo" {:sort-order :by-name})
-    => (contains [{:ns "clojure.core", :type :function, :candidate "remove-method"}
-                  {:ns "clojure.core", :type :function, :candidate "remove-ns"}
-                  {:ns "clojure.core", :type :function, :candidate "remove-watch"}]
+    => (contains [{:ns "clojure.core", :type :function, :candidate "remove-method", :private false}
+                  {:ns "clojure.core", :type :function, :candidate "remove-ns", :private false}
+                  {:ns "clojure.core", :type :function, :candidate "remove-watch", :private false}]
                  :gaps-ok))
 
 
@@ -102,16 +102,17 @@
 
   (fact "different metadata is attached to candidates"
     (core/completions "bound" {}) =>
-    (contains #{{:ns "clojure.core", :type :function, :candidate "bound-fn*"}
-                {:ns "clojure.core", :type :macro, :candidate "bound-fn"}} :gaps-ok)
+    (contains #{{:ns "clojure.core", :type :function, :candidate "bound-fn*", :private false}
+                {:ns "clojure.core", :type :macro, :candidate "bound-fn", :private false}}
+              :gaps-ok)
 
     (core/completions "fac" {:ns (find-ns 'fudje.sweet)})
-    => (just [{:candidate "fact", :type :macro, :ns "fudje.sweet"}
-              {:candidate "facts", :type :macro, :ns "fudje.sweet"}]
+    => (just [{:candidate "fact", :type :macro, :ns "fudje.sweet", :private false}
+              {:candidate "facts", :type :macro, :ns "fudje.sweet", :private false}]
              :in-any-order)
 
     (core/completions "a-big-" {:ns 'compliment.t-core})
-    => (just [{:ns "compliment.t-core", :type :var, :candidate "a-big-int"}])
+    => (just [{:ns "compliment.t-core", :type :var, :candidate "a-big-int", :private false}])
 
     (core/completions "cl.se" {}) =>
     (contains [{:candidate "clojure.set", :type :namespace}])
@@ -167,7 +168,7 @@
 
   (fact "extra-metadata arglists"
     (core/completions "apply" {:extra-metadata #{:arglists}})
-    => (contains #{{:ns "clojure.core", :type :function, :candidate "apply", :arglists '("[f args]" "[f x args]" "[f x y args]" "[f x y z args]" "[f a b c d & args]")}}
+    => (contains #{{:ns "clojure.core", :type :function, :private false, :candidate "apply", :arglists '("[f args]" "[f x args]" "[f x y args]" "[f x y z args]" "[f a b c d & args]")}}
                  :gaps-ok))
 
   (fact "extra-metadata doc"

--- a/test/compliment/t_core.clj
+++ b/test/compliment/t_core.clj
@@ -75,9 +75,9 @@
     => (contains ["map-indexed" "map?" "mapcat" "mapv"] :gaps-ok)
 
     (core/completions "remo" {:sort-order :by-name})
-    => (contains [{:ns "clojure.core", :type :function, :candidate "remove-method", :private false}
-                  {:ns "clojure.core", :type :function, :candidate "remove-ns", :private false}
-                  {:ns "clojure.core", :type :function, :candidate "remove-watch", :private false}]
+    => (contains [{:ns "clojure.core", :type :function, :candidate "remove-method", :private false, :deprecated false}
+                  {:ns "clojure.core", :type :function, :candidate "remove-ns", :private false, :deprecated false}
+                  {:ns "clojure.core", :type :function, :candidate "remove-watch", :private false, :deprecated false}]
                  :gaps-ok))
 
 
@@ -102,17 +102,17 @@
 
   (fact "different metadata is attached to candidates"
     (core/completions "bound" {}) =>
-    (contains #{{:ns "clojure.core", :type :function, :candidate "bound-fn*", :private false}
-                {:ns "clojure.core", :type :macro, :candidate "bound-fn", :private false}}
+    (contains #{{:ns "clojure.core", :type :function, :candidate "bound-fn*", :private false, :deprecated false}
+                {:ns "clojure.core", :type :macro, :candidate "bound-fn", :private false, :deprecated false}}
               :gaps-ok)
 
     (core/completions "fac" {:ns (find-ns 'fudje.sweet)})
-    => (just [{:candidate "fact", :type :macro, :ns "fudje.sweet", :private false}
-              {:candidate "facts", :type :macro, :ns "fudje.sweet", :private false}]
+    => (just [{:candidate "fact", :type :macro, :ns "fudje.sweet", :private false, :deprecated false}
+              {:candidate "facts", :type :macro, :ns "fudje.sweet", :private false, :deprecated false}]
              :in-any-order)
 
     (core/completions "a-big-" {:ns 'compliment.t-core})
-    => (just [{:ns "compliment.t-core", :type :var, :candidate "a-big-int", :private false}])
+    => (just [{:ns "compliment.t-core", :type :var, :candidate "a-big-int", :private false, :deprecated false}])
 
     (core/completions "cl.se" {}) =>
     (contains [{:candidate "clojure.set", :type :namespace}])
@@ -168,7 +168,7 @@
 
   (fact "extra-metadata arglists"
     (core/completions "apply" {:extra-metadata #{:arglists}})
-    => (contains #{{:ns "clojure.core", :type :function, :private false, :candidate "apply", :arglists '("[f args]" "[f x args]" "[f x y args]" "[f x y z args]" "[f a b c d & args]")}}
+    => (contains #{{:ns "clojure.core", :type :function, :private false, :deprecated false, :candidate "apply", :arglists '("[f args]" "[f x args]" "[f x y args]" "[f x y z args]" "[f a b c d & args]")}}
                  :gaps-ok))
 
   (fact "extra-metadata doc"


### PR DESCRIPTION
This PR adds two things:
- the earlier discussed suggestion of private vars when using `#'some-ns/,,,`
- adding a `:deprecated` key to suggested vars and functions