### PR TITLE
Suggest private vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change log
 
+### Unreleased
+
+- [#98](https://github.com/alexander-yakushev/compliment/pull/98): Find private vars when using var quote literal.
+
 ### 0.3.16 (2023-06-23)
 
-- [#91](https://github.com/alexander-yakushev/compliment/pull/97): Extend
+- [#97](https://github.com/alexander-yakushev/compliment/pull/97): Extend
   completion and getting docs for symbol-strings with leading literals.
 
 ### 0.3.15 (2023-06-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - [#98](https://github.com/alexander-yakushev/compliment/pull/98): Find private vars when using var quote literal.
+- [#98](https://github.com/alexander-yakushev/compliment/pull/98): Support `:private` and `:deprecated` as extra-metadata.
 
 ### 0.3.16 (2023-06-23)
 

--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -85,7 +85,7 @@
                    :else (ns-map ns))]
         (for [[var-sym var] vars
               :let [var-name (name var-sym)
-                    {:keys [arglists doc] :as var-meta} (meta var)]
+                    {:keys [arglists doc private deprecated] :as var-meta} (meta var)]
               :when (and (dash-matches? prefix var-name)
                          (not (:completion/hidden var-meta)))]
           (if (= (type var) Class)
@@ -102,6 +102,12 @@
                                  arglists :function
                                  :else :var)
                      :ns (str (or (:ns var-meta) ns))}
+              (and private (:private *extra-metadata*))
+              (assoc :private (boolean private))
+
+              (and deprecated (:deprecated *extra-metadata*))
+              (assoc :deprecated (boolean deprecated))
+
               (and arglists (:arglists *extra-metadata*))
               (assoc :arglists (apply list (map pr-str arglists)))
 

--- a/src/compliment/sources/ns_mappings.clj
+++ b/src/compliment/sources/ns_mappings.clj
@@ -74,12 +74,13 @@
   either the scope (if prefix is scoped), `ns` arg or the namespace
   extracted from context if inside `ns` declaration."
   [^String prefix, ns context]
-  (let [[literals prefix] (split-by-leading-literals prefix)]
+  (let [[literals prefix] (split-by-leading-literals prefix)
+        var-quote? (when literals (re-find #"#'$" literals))]
     (when (var-symbol? prefix)
       (let [[scope-name scope ^String prefix] (get-scope-and-prefix prefix ns)
             ns-form-namespace (try-get-ns-from-context context)
             vars (cond
-                   scope (ns-publics scope)
+                   scope (if var-quote? (ns-interns scope) (ns-publics scope))
                    ns-form-namespace (ns-publics ns-form-namespace)
                    :else (ns-map ns))]
         (for [[var-sym var] vars

--- a/test/compliment/sources/t_ns_mappings.clj
+++ b/test/compliment/sources/t_ns_mappings.clj
@@ -108,6 +108,16 @@
     (strip-tags (src/candidates "@some-a" (-ns) nil))
     => (just ["@some-atom"]))
 
+  (fact "private vars will be suggested when prefixed with var quote"
+    ;; no candidate for a non-public var
+    (strip-tags (src/candidates "clojure.core/print-tagged-object" (-ns) nil))
+    => (just [])
+    ;; var quote works though
+    (strip-tags (src/candidates "#'clojure.core/print-tagged-object" (-ns) nil))
+    => (just [ "#'clojure.core/print-tagged-object"])
+    (strip-tags (src/candidates "#'src/resolve-var" (-ns) nil))
+    => (just ["#'src/resolve-var"]))
+
   (def foo:bar 1)
   (def foo:baz 2)
   (fact "handles vars with semicolons in them"

--- a/test/compliment/sources/t_ns_mappings.clj
+++ b/test/compliment/sources/t_ns_mappings.clj
@@ -130,16 +130,16 @@
     (strip-tags (src/candidates "foo:b" (-ns) nil))
     => (contains #{"foo:bar" "foo:baz"} :gaps-ok))
 
+  (defn ^:deprecated ^:private some-deprecated-private-fn "Some doc" [])
   (fact "extra metadata can be requested from this completion source"
-    (binding [*extra-metadata* #{:doc :arglists}]
-      (doall (src/candidates "freq" (-ns) nil)))
-    => [{:candidate "frequencies", :type :function, :ns "clojure.core"
-         :arglists ["[coll]"]
+    (binding [*extra-metadata* #{:doc :arglists :private :deprecated}]
+      (doall (src/candidates "some-deprecated-private-fn" (-ns) nil)))
+    => [{:candidate "some-deprecated-private-fn", :type :function, :ns "compliment.sources.t-ns-mappings"
+         :private true, :deprecated true, :arglists ["[]"]
          :doc (clojure.string/join
                (System/lineSeparator)
-               ["clojure.core/frequencies" "([coll])"
-                "  Returns a map from distinct items in coll to the number of times
-  they appear." ""])}])
+               ["compliment.sources.t-ns-mappings/some-deprecated-private-fn" "([])"
+                "  Some doc" ""])}])
 
   (defn should-appear [])
   (defn ^:completion/hidden shouldnt-appear [])


### PR DESCRIPTION
This PR adds two things:
- the earlier discussed suggestion of private vars when using `#'some-ns/,,,`
- adding a `:deprecated` key to suggested vars and functions