### PR TITLE
Recognize target class within ->, ->>, doto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - [#33](https://github.com/alexander-yakushev/compliment/issues/33): Demunge
   deftype field names.
+- [#61](https://github.com/alexander-yakushev/compliment/issues/61): Introduce
+  support for offering completions within the context of a  `->`, `->>` and
+  `doto` call.
 
 ### 0.4.0 (2023-07-05)
 

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
                                   [criterium "0.4.6"]
                                   [fudje "0.9.7"]]
-                   :plugins [[jonase/eastwood "1.3.0"]
+                   :plugins [[jonase/eastwood "1.4.0"]
                              [lein-cloverage "1.2.4"]]
                    :eastwood {:ignored-faults {:bad-arglists {compliment.sources.t-local-bindings true}
                                                :def-in-def {compliment.sources.t-class-members true

--- a/src/compliment/context.clj
+++ b/src/compliment/context.clj
@@ -91,7 +91,6 @@
                        (-> x first symbol?)
                        (contains? #{#'clojure.core/->
                                     #'clojure.core/->>
-                                    #'clojure.core/..
                                     #'clojure.core/doto}
                                   (ns-resolve ns (first x))))
                 (macroexpand-1 x)

--- a/src/compliment/context.clj
+++ b/src/compliment/context.clj
@@ -93,7 +93,7 @@
                                     #'clojure.core/->>
                                     #'clojure.core/..
                                     #'clojure.core/doto}
-                                  (->> x first (ns-resolve ns))))
+                                  (ns-resolve ns (first x))))
                 (macroexpand-1 x)
                 x))
             form))

--- a/src/compliment/context.clj
+++ b/src/compliment/context.clj
@@ -87,7 +87,7 @@
 
 (defn macroexpand-form [ns form]
   (postwalk (fn [x]
-              (if (and (list? x)
+              (if (and (seq? x)
                        (-> x first symbol?)
                        (contains? #{#'clojure.core/->
                                     #'clojure.core/->>

--- a/src/compliment/core.clj
+++ b/src/compliment/core.clj
@@ -56,7 +56,8 @@
             :or {sort-order :by-length}} options-map
            nspc (ensure-ns (:ns options-map))
            options-map (assoc options-map :ns nspc)
-           ctx (cache-context context)]
+           ctx (binding [*ns* nspc]
+                 (cache-context context))]
        (binding [*extra-metadata* extra-metadata]
          (let [candidate-fns (keep (fn [[_ src]]
                                      (when (:enabled src)

--- a/src/compliment/sources/class_members.clj
+++ b/src/compliment/sources/class_members.clj
@@ -97,8 +97,7 @@
         (resolve-class ns tag)
         ;; Otherwise, try to resolve symbol to a Var.
         (or (utils/var->class ns form)
-            (utils/invocation-form->class ns form)
-            (utils/java-interop->class ns form))))))
+            (utils/invocation-form->class ns form))))))
 
 (defn members-candidates
   "Returns a list of Java non-static fields and methods candidates."

--- a/src/compliment/sources/class_members.clj
+++ b/src/compliment/sources/class_members.clj
@@ -1,10 +1,12 @@
 (ns compliment.sources.class-members
   "Completion for both static and non-static class members."
-  (:require [compliment.sources :refer [defsource]]
+  (:require [clojure.string :refer [join]]
+            [clojure.walk :as walk]
+            [compliment.sources :refer [defsource]]
             [compliment.sources.local-bindings :refer [bindings-from-context]]
             [compliment.utils :refer [fuzzy-matches-no-skip? resolve-class]]
-            [clojure.string :refer [join]])
-  (:import [java.lang.reflect Method Field Member Modifier]))
+            [compliment.utils :as utils])
+  (:import [java.lang.reflect Field Member Method Modifier]))
 
 (defn static?
   "Tests if class member is static."
@@ -94,9 +96,9 @@
         ;; We have a tag - try to resolve the class from it.
         (resolve-class ns tag)
         ;; Otherwise, try to resolve symbol to a Var.
-        (let [obj (and (symbol? form) (ns-resolve ns form))]
-          (and (= (class obj) clojure.lang.Var)
-               (class (deref obj))))))))
+        (or (utils/var->class ns form)
+            (utils/invocation-form->class ns form)
+            (utils/java-interop->class ns form))))))
 
 (defn members-candidates
   "Returns a list of Java non-static fields and methods candidates."

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -97,7 +97,7 @@
   "When given a form that has a binding vector traverses that binding vector and
   returns the list of all local bindings."
   [form ns]
-  (when (utils/list-like? form)
+  (when (seq? form)
     (let [sym (first form)
           locals-meta (when (symbol? sym)
                         (:completion/locals (meta (ns-resolve ns sym))))]

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -29,13 +29,11 @@
 
 (defn- doseq-like-form? [x]
   (and (symbol? x)
-       (contains? #{"doseq" "for"}
-                  (name x))))
+       (contains? #{"doseq" "for"} (name x))))
 
 (defn- letfn-like-form? [x]
   (and (symbol? x)
-       (contains? #{"letfn"}
-                  (name x))))
+       (contains? #{"letfn"} (name x))))
 
 (def destructuring-key-names #{"keys" "strs" "syms"})
 

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -75,8 +75,7 @@
             as-bind (conj as-bind)))
 
         (not (#{'& '_} binding-node))
-        (let [result binding-node
-              candidate (delay (extract-tag-from-bound-to ns bound-to))]
+        (let [result binding-node]
           (if (-> result meta :tag)
             [result]
             (if-let [candidate (extract-tag-from-bound-to ns bound-to)]

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -68,13 +68,11 @@
         (not (#{'& '_} binding-node))
         (let [result binding-node
               candidate (delay (extract-tag-from-bound-to ns bound-to))]
-          (cond-> result
-            (and (not (-> result meta :tag))
-                 @candidate)
-            (vary-meta assoc :tag @candidate)
-
-            true
-            vector))))
+          (if (-> result meta :tag)
+            [result]
+            (if-let [candidate (extract-tag-from-bound-to ns bound-to)]
+              [(vary-meta result assoc :tag candidate)]
+              [result])))))
 
 (defn parse-fn-body
   "Extract function name and arglists from the function body, return list of all

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -1,30 +1,58 @@
 (ns compliment.sources.local-bindings
   "Completion source for local bindings introduced by defn, let and the like."
   (:require [compliment.sources :refer [defsource]]
-            [compliment.sources.ns-mappings :refer [var-symbol? dash-matches?]]))
+            [compliment.sources.ns-mappings :refer [var-symbol? dash-matches?]]
+            [compliment.utils :as utils]))
 
-(def let-like-forms '#{let if-let when-let if-some when-some loop with-open
-                       dotimes with-local-vars})
+;; syntax-quoted variants are important for when we perform macroexpansion as part of our processing.
+(def let-like-forms #{'let `let
+                      'if-let `if-let
+                      'when-let `when-let
+                      'if-some `if-some
+                      'when-some `when-some
+                      'loop `loop
+                      'with-open `with-open
+                      'dotimes `dotimes
+                      'with-local-vars `with-local-vars})
 
-(def defn-like-forms '#{defn defn- fn defmacro defmethod})
+(def defn-like-forms #{'defn `defn
+                       'defn- `defn-
+                       'fn `fn
+                       `fn*
+                       'defmacro `defmacro
+                       'defmethod `defmethod})
 
-(def doseq-like-forms '#{doseq for})
+(def doseq-like-forms #{'doseq `doseq
+                        'for `for})
 
-(def letfn-like-forms '#{letfn})
+(def letfn-like-forms #{'letfn `letfn})
 
 (def destructuring-key-names #{"keys" "strs" "syms"})
+
+(defn extract-tag-from-bound-to [ns bound-to]
+  (when bound-to
+    (when-let [found (or (-> bound-to meta :tag)
+                         (utils/var->class ns bound-to)
+                         (utils/invocation-form->class ns bound-to)
+                         (utils/java-interop->class ns bound-to))]
+      (if (class? found)
+        (-> ^Class found .getName symbol)
+        found))))
 
 (defn parse-binding
   "Given a binding node returns the list of local bindings introduced by that
   node. Handles vector and map destructuring."
-  [binding-node]
+  [ns binding-node bound-to]
   (cond (vector? binding-node)
-        (mapcat parse-binding binding-node)
+        (mapcat (fn [x]
+                  (parse-binding ns x nil))
+                binding-node)
 
         (map? binding-node)
         (let [normal-binds (->> (keys binding-node)
                                 (remove keyword?)
-                                (mapcat parse-binding))
+                                (mapcat (fn [x]
+                                          (parse-binding ns x nil))))
               keys-binds (->> binding-node
                               (mapcat (fn [[k v]]
                                         ;; This handles both plain and
@@ -38,17 +66,26 @@
             as-bind (conj as-bind)))
 
         (not (#{'& '_} binding-node))
-        [binding-node]))
+        (let [result binding-node
+              candidate (delay (extract-tag-from-bound-to ns bound-to))]
+          (cond-> result
+            (and (not (-> result meta :tag))
+                 @candidate)
+            (vary-meta assoc :tag @candidate)
+
+            true
+            vector))))
 
 (defn parse-fn-body
   "Extract function name and arglists from the function body, return list of all
   completable variables."
-  [fn-body]
+  [ns fn-body]
   (let [fn-name (when (symbol? (first fn-body))
                   (first fn-body))
         fn-body (if fn-name (rest fn-body) fn-body)]
     (cond->
-        (mapcat parse-binding
+        (mapcat (fn [x]
+                  (parse-binding ns x nil))
                 (loop [[c & r] fn-body, bnodes []]
                   (cond (nil? c) bnodes
                         (list? c) (recur r (conj bnodes (first c))) ;; multi-arity case
@@ -60,25 +97,30 @@
   "When given a form that has a binding vector traverses that binding vector and
   returns the list of all local bindings."
   [form ns]
-  (when (list? form)
+  (when (utils/list-like? form)
     (let [sym (first form)
           locals-meta (when (symbol? sym)
                         (:completion/locals (meta (ns-resolve ns sym))))]
       (cond (or (let-like-forms sym) (= locals-meta :let))
-            (mapcat parse-binding (take-nth 2 (second form)))
+            (mapcat (fn [[x y]]
+                      (parse-binding ns x y))
+                    (partition 2 (second form)))
 
             (or (defn-like-forms sym) (= locals-meta :defn))
-            (parse-fn-body (rest form))
+            (parse-fn-body ns (rest form))
 
             (or (letfn-like-forms sym) (= locals-meta :letfn))
-            (mapcat parse-fn-body (second form))
+            (mapcat (fn [fn-body]
+                      (parse-fn-body ns fn-body))
+                    (second form))
 
             (or (doseq-like-forms sym) (= locals-meta :doseq))
             (->> (partition 2 (second form))
                  (mapcat (fn [[left right]]
                            (if (= left :let)
                              (take-nth 2 right) [left])))
-                 (mapcat parse-binding))
+                 (mapcat (fn [x]
+                           (parse-binding ns x nil))))
 
             (= sym 'as->) [(nth form 2)]))))
 

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -75,12 +75,11 @@
             as-bind (conj as-bind)))
 
         (not (#{'& '_} binding-node))
-        (let [result binding-node]
-          [(if (-> result meta :tag)
-             result
-             (if-let [candidate (extract-tag-from-bound-to ns bound-to)]
-               (vary-meta result assoc :tag candidate)
-               result))])))
+        [(if (-> binding-node meta :tag)
+           binding-node
+           (if-let [candidate (extract-tag-from-bound-to ns bound-to)]
+             (vary-meta binding-node assoc :tag candidate)
+             binding-node))]))
 
 (defn parse-fn-body
   "Extract function name and arglists from the function body, return list of all

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -76,11 +76,11 @@
 
         (not (#{'& '_} binding-node))
         (let [result binding-node]
-          (if (-> result meta :tag)
-            [result]
-            (if-let [candidate (extract-tag-from-bound-to ns bound-to)]
-              [(vary-meta result assoc :tag candidate)]
-              [result])))))
+          [(if (-> result meta :tag)
+             result
+             (if-let [candidate (extract-tag-from-bound-to ns bound-to)]
+               (vary-meta result assoc :tag candidate)
+               result))])))
 
 (defn parse-fn-body
   "Extract function name and arglists from the function body, return list of all

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -33,8 +33,7 @@
   (when bound-to
     (when-let [found (or (-> bound-to meta :tag)
                          (utils/var->class ns bound-to)
-                         (utils/invocation-form->class ns bound-to)
-                         (utils/java-interop->class ns bound-to))]
+                         (utils/invocation-form->class ns bound-to))]
       (if (class? found)
         (-> ^Class found .getName symbol)
         found))))

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -1,10 +1,10 @@
 (ns compliment.utils
   "Functions and utilities for source implementations."
-  (:import [clojure.lang Cons LazySeq Var]
-           [java.io File]
-           [java.nio.file Files]
-           [java.util.function Consumer]
-           [java.util.jar JarEntry JarFile]))
+  (:import (clojure.lang Cons LazySeq)
+           java.io.File
+           java.nio.file.Files
+           java.util.function.Consumer
+           (java.util.jar JarEntry JarFile)))
 
 ;; Disable reflection warnings in this file because we must use reflection to
 ;; support both JDK8 and JDK9+.
@@ -245,14 +245,16 @@ Note that should always have the same value, regardless of OS."
             (replace File/separator resource-separator))))))
 
 (defn var->class
-  "Given a form that may be a var, returns the class that is associated to its :tag or its value (in that precedence order)."
+  "Given a form that may be a var, returns the class that is associated
+  to its :tag or its value (in that precedence order)."
   [ns form]
   (when-let [var-ref (and (symbol? form)
                           (let [found (ns-resolve ns form)]
                             (when (var? found)
                               found)))]
     ;; let :tag take precedence - maybe the :tag says "this is an IFoo" (interface),
-    ;; and the class says "this is a FooImpl" (concrete class, which maybe has worse documentation
+    ;; and the class says "this is a FooImpl"
+    ;; (concrete class, which maybe has worse documentation
     ;; or other inheritance intricacies)
     (or (-> var-ref meta :tag)
         (class (deref var-ref)))))
@@ -264,5 +266,5 @@ Note that should always have the same value, regardless of OS."
   (when-let [var-from-invocation (and (seq? form)
                                       (symbol? (first form))
                                       (ns-resolve ns (first form)))]
-    (when (= (class var-from-invocation) Var)
+    (when (var? var-from-invocation)
       (-> var-from-invocation meta :tag))))

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -1,8 +1,10 @@
 (ns compliment.utils
   "Functions and utilities for source implementations."
-  (:import java.io.File java.nio.file.Files
-           (java.util.jar JarFile JarEntry)
-           java.util.function.Consumer))
+  (:import [clojure.lang Cons LazySeq Var]
+           [java.io File]
+           [java.nio.file Files]
+           [java.util.function Consumer]
+           [java.util.jar JarEntry JarFile]))
 
 ;; Disable reflection warnings in this file because we must use reflection to
 ;; support both JDK8 and JDK9+.
@@ -241,3 +243,38 @@ Note that should always have the same value, regardless of OS."
         ;; resource pathes always use "/" regardless of platform
         (.. (ensure-no-leading-slash file)
             (replace File/separator resource-separator))))))
+
+(defn list-like? [form]
+  (or (list? form) ;; normally returned be the reader
+      (instance? Cons form) ;; occasionally returned be the reader
+      (instance? LazySeq form) ;; produced by our macroexpansion business
+      ))
+
+(defn var->class
+  "Given a form that may be a var, returns the class that is associated to its :tag or its value (in that precedence order)."
+  [ns form]
+  (when-let [var-ref (and (symbol? form)
+                          (when-let [found (some->> form (ns-resolve ns))]
+                            (when (var? found)
+                              found)))]
+    ;; let :tag take precedence - maybe the :tag says "this is an IFoo" (interface),
+    ;; and the class says "this is a FooImpl" (concrete class, which maybe has worse documentation
+    ;; or other inheritance intricacies)
+    (or (-> var-ref meta :tag)
+        (class (deref var-ref)))))
+
+(defn invocation-form->class
+  "Given a form that might be an invocation form (i.e. a list),
+  return the class that is returned, according to the invoked function's var metadata."
+  [ns form]
+  (when-let [var-from-invocation (and (list-like? form)
+                                      (symbol? (first form))
+                                      (ns-resolve ns (first form)))]
+    (and (= (class var-from-invocation) Var)
+         (-> var-from-invocation meta :tag))))
+
+(defn java-interop->class
+  "Given a `form` that may represent a Java interop form (e.g. constructor call, method call), return its class."
+  [ns form]
+  ;; TODO implement
+  nil)

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -266,9 +266,3 @@ Note that should always have the same value, regardless of OS."
                                       (ns-resolve ns (first form)))]
     (when (= (class var-from-invocation) Var)
       (-> var-from-invocation meta :tag))))
-
-(defn java-interop->class
-  "Given a `form` that may represent a Java interop form (e.g. constructor call, method call), return its class."
-  [ns form]
-  ;; TODO implement
-  nil)

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -244,12 +244,6 @@ Note that should always have the same value, regardless of OS."
         (.. (ensure-no-leading-slash file)
             (replace File/separator resource-separator))))))
 
-(defn list-like? [form]
-  (or (list? form) ;; normally returned be the reader
-      (instance? Cons form) ;; occasionally returned be the reader
-      (instance? LazySeq form) ;; produced by our macroexpansion business
-      ))
-
 (defn var->class
   "Given a form that may be a var, returns the class that is associated to its :tag or its value (in that precedence order)."
   [ns form]
@@ -267,7 +261,7 @@ Note that should always have the same value, regardless of OS."
   "Given a form that might be an invocation form (i.e. a list),
   return the class that is returned, according to the invoked function's var metadata."
   [ns form]
-  (when-let [var-from-invocation (and (list-like? form)
+  (when-let [var-from-invocation (and (seq? form)
                                       (symbol? (first form))
                                       (ns-resolve ns (first form)))]
     (and (= (class var-from-invocation) Var)

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -248,7 +248,7 @@ Note that should always have the same value, regardless of OS."
   "Given a form that may be a var, returns the class that is associated to its :tag or its value (in that precedence order)."
   [ns form]
   (when-let [var-ref (and (symbol? form)
-                          (when-let [found (some->> form (ns-resolve ns))]
+                          (let [found (ns-resolve ns form)]
                             (when (var? found)
                               found)))]
     ;; let :tag take precedence - maybe the :tag says "this is an IFoo" (interface),

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -264,8 +264,8 @@ Note that should always have the same value, regardless of OS."
   (when-let [var-from-invocation (and (seq? form)
                                       (symbol? (first form))
                                       (ns-resolve ns (first form)))]
-    (and (= (class var-from-invocation) Var)
-         (-> var-from-invocation meta :tag))))
+    (when (= (class var-from-invocation) Var)
+      (-> var-from-invocation meta :tag))))
 
 (defn java-interop->class
   "Given a `form` that may represent a Java interop form (e.g. constructor call, method call), return its class."

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -1,7 +1,6 @@
 (ns compliment.utils
   "Functions and utilities for source implementations."
-  (:import (clojure.lang Cons LazySeq)
-           java.io.File
+  (:import java.io.File
            java.nio.file.Files
            java.util.function.Consumer
            (java.util.jar JarEntry JarFile)))

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -44,6 +44,24 @@
                                                       "(-> x ^Thread (anything) __prefix__ FOO)")))
     => (just '(".interrupt"))))
 
+(deftest thread-last-test
+  (fact "`->>` works with Compliment"
+    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
+                                                     "(->> [] (clojure.string/join \"a\") __prefix__)")))
+    => (just '(".subSequence" ".substring") :in-any-order)
+
+    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
+                                                     "(->> [] (clojure.string/join \"a\") __prefix__ FOO)")))
+    => (just '(".subSequence" ".substring") :in-any-order)
+
+    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
+                                                     "(->> [] ^Thread (anything) __prefix__ )")))
+    => (just '(".suspend"))
+
+    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
+                                                     "(->> thread __prefix__)")))
+    => (just '(".suspend"))))
+
 (deftest doto-test
   (in-ns 'compliment.sources.t-class-members)
   (fact "`doto` works with Compliment"

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -12,13 +12,13 @@
 (deftest thread-first-test
   (in-ns 'compliment.sources.t-class-members)
   (fact "`->` works with Compliment"
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(-> thread __prefix__)")))
-    => (just '(".suspend"))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(-> thread __prefix__)")))
+    => (just '(".interrupt"))
 
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(-> thread __prefix__ FOO)")))
-    => (just '(".suspend"))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(-> thread __prefix__ FOO)")))
+    => (just '(".interrupt"))
 
     (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
                                                      "(-> \"\" clojure.string/trim __prefix__)")))
@@ -36,24 +36,24 @@
                                                      "(-> [] (clojure.string/join) __prefix__ FOO)")))
     => (just '(".subSequence" ".substring") :in-any-order)
 
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(-> x ^Thread (anything) __prefix__)")))
-    => (just '(".suspend"))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(-> x ^Thread (anything) __prefix__)")))
+    => (just '(".interrupt"))
 
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(-> x ^Thread (anything) __prefix__ FOO)")))
-    => (just '(".suspend"))))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(-> x ^Thread (anything) __prefix__ FOO)")))
+    => (just '(".interrupt"))))
 
 (deftest doto-test
   (in-ns 'compliment.sources.t-class-members)
   (fact "`doto` works with Compliment"
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(doto thread __prefix__)")))
-    => (just '(".suspend"))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(doto thread __prefix__)")))
+    => (just '(".interrupt"))
 
-    (strip-tags (src/members-candidates ".su" (-ns) (ctx/cache-context
-                                                     "(doto thread (__prefix__))")))
-    => (just '(".suspend"))))
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(doto thread (__prefix__))")))
+    => (just '(".interrupt"))))
 
 (deftest class-members-test
   (in-ns 'compliment.sources.t-class-members)

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -71,6 +71,14 @@
 
     (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
                                                       "(doto thread (__prefix__))")))
+    => (just '(".interrupt"))
+
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(doto thread .checkAccess (__prefix__))")))
+    => (just '(".interrupt"))
+
+    (strip-tags (src/members-candidates ".int" (-ns) (ctx/cache-context
+                                                      "(doto thread (__prefix__) .checkAccess)")))
     => (just '(".interrupt"))))
 
 (deftest class-members-test


### PR DESCRIPTION
> Closes https://github.com/alexander-yakushev/compliment/issues/61

Introduces support for ->, ->> and doto, by macroexpanding things in a sensible and constrained manner.

~(also .., but code coverage is pending atm)~

Other refinements are introduced so that ->/doto is actually useful. In specific terms, types are now better propagated/perceived when encountering vars, and `let` bindings (note: doto expands to a `let`, which is why it's important), etc.

Build is green:

<img width="611" alt="image" src="https://github.com/alexander-yakushev/compliment/assets/1162994/5b6c3204-7835-4311-ae68-a64281054aae">

Looking forward to feedback.

Cheers - V