### PR TITLE
Infer the class of string and coll literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### master (unreleased)
 
+- Infer the class string and coll literals, giving more accurate completions for those.
+
 ### 0.4.1 (2023-08-23)
 
 - [#33](https://github.com/alexander-yakushev/compliment/issues/33): Demunge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### master (unreleased)
 
-- Infer the class string and coll literals, giving more accurate completions for those.
+- Infer the class of string and coll literals, giving more accurate completions for those.
 
 ### 0.4.1 (2023-08-23)
 

--- a/src/compliment/sources/class_members.clj
+++ b/src/compliment/sources/class_members.clj
@@ -105,9 +105,11 @@
                     (:tag (meta (get (set (bindings-from-context context ns)) form))))]
         ;; We have a tag - try to resolve the class from it.
         (resolve-class ns tag)
-        ;; Otherwise, try to resolve symbol to a Var.
+        ;; Otherwise, try to resolve symbol to a Var,
+        ;; or literal to class.
         (or (utils/var->class ns form)
-            (utils/invocation-form->class ns form))))))
+            (utils/invocation-form->class ns form)
+            (utils/literal->class form))))))
 
 (defn members-candidates
   "Returns a list of Java non-static fields and methods candidates."
@@ -222,7 +224,7 @@
       (if (static? c)
         (let [full-name (.getName c)]
           (if (cache (.getName c))
-            (recur (update-in cache [full-name] conj c) r)
+            (recur (update cache full-name conj c) r)
             (recur (assoc cache full-name [c]) r)))
         (recur cache r))
       (swap! static-members-cache assoc class cache))))

--- a/src/compliment/sources/local_bindings.clj
+++ b/src/compliment/sources/local_bindings.clj
@@ -41,7 +41,8 @@
   (when bound-to
     (when-let [found (or (-> bound-to meta :tag)
                          (utils/var->class ns bound-to)
-                         (utils/invocation-form->class ns bound-to))]
+                         (utils/invocation-form->class ns bound-to)
+                         (utils/literal->class bound-to))]
       (if (class? found)
         (-> ^Class found .getName symbol)
         found))))

--- a/src/compliment/utils.clj
+++ b/src/compliment/utils.clj
@@ -267,3 +267,11 @@ Note that should always have the same value, regardless of OS."
                                       (ns-resolve ns (first form)))]
     (when (var? var-from-invocation)
       (-> var-from-invocation meta :tag))))
+
+(defn literal->class
+  "Extracts the class from a literal.
+  This is meant to support interop on strings and Clojure collections."
+  [form]
+  (when (or (string? form)
+            (coll? form))
+    (class form)))

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -227,7 +227,16 @@ which indicates that the members are an exact match against the class of `[]`"
         candidates-count => expected))
 
     (fact "A docstring is offered for the previous query"
-      (src/members-doc ".assocN" (-ns)) => (checker string?)))
+      (src/members-doc ".assocN" (-ns)) => (checker string?))
+
+    (fact "Only returns members of clojure.lang.PersistentVector for the very short \".a\" query"
+      (src/members-candidates ".a" (-ns) (ctx/cache-context
+                                          "(__prefix__ [])"))
+      =>
+      (just [{:candidate ".arrayFor", :type :method}
+             {:candidate ".assocN", :type :method}
+             {:candidate ".asTransient", :type :method}]
+        :in-any-order)))
 
   (testing "String literals"
     (let [candidates-count (count (src/members-candidates "." (-ns) (ctx/cache-context
@@ -236,10 +245,19 @@ which indicates that the members are an exact match against the class of `[]`"
                      1 35
                      11 43
                      50)]
+
       (fact "Has around 50 candidates (give or take, varies per JDK),
 which indicates that the members are an exact match against the class of `\"\"`"
         candidates-count => expected))
 
     (fact "A docstring is offered for the previous query"
       (src/members-doc ".codePointBefore" (-ns))
-      => (checker string?))))
+      => (checker string?))
+
+    (fact "Only returns members of String for the very short \".g\" query"
+      (src/members-candidates ".g" (-ns) (ctx/cache-context
+                                          "(__prefix__ \"\")"))
+      =>
+      (just [{:candidate ".getChars", :type :method}
+             {:candidate ".getBytes", :type :method}]
+        :in-any-order))))

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -208,27 +208,8 @@
   (fact "static class members have docs"
     (src/static-member-doc "Integer/parseInt" (-ns)) => (checker string?)))
 
-(def java-version (-> (System/getProperty "java.version")
-                      (str/split #"\.")
-                      first
-                      read-string))
-
 (deftest literals-inference-test
   (testing "Vector literals"
-    (let [candidates-count (count (src/members-candidates "." (-ns) (ctx/cache-context
-                                                                     "(__prefix__ [])")))
-          {:keys [major minor]} *clojure-version*
-          expected (if (and (= 1 major)
-                            (< minor 12))
-                     18
-                     19)]
-      (fact "Has around 19 candidates (give or take, varies per *clojure-version*),
-which indicates that the members are an exact match against the class of `[]`"
-        candidates-count => expected))
-
-    (fact "A docstring is offered for the previous query"
-      (src/members-doc ".assocN" (-ns)) => (checker string?))
-
     (fact "Only returns members of clojure.lang.PersistentVector for the very short \".a\" query"
       (src/members-candidates ".a" (-ns) (ctx/cache-context
                                           "(__prefix__ [])"))
@@ -236,28 +217,20 @@ which indicates that the members are an exact match against the class of `[]`"
       (just [{:candidate ".arrayFor", :type :method}
              {:candidate ".assocN", :type :method}
              {:candidate ".asTransient", :type :method}]
-        :in-any-order)))
-
-  (testing "String literals"
-    (let [candidates-count (count (src/members-candidates "." (-ns) (ctx/cache-context
-                                                                     "(__prefix__ \"\")")))
-          expected (case java-version
-                     1 35
-                     11 43
-                     50)]
-
-      (fact "Has around 50 candidates (give or take, varies per JDK),
-which indicates that the members are an exact match against the class of `\"\"`"
-        candidates-count => expected))
+        :in-any-order))
 
     (fact "A docstring is offered for the previous query"
-      (src/members-doc ".codePointBefore" (-ns))
-      => (checker string?))
+      (src/members-doc ".assocN" (-ns)) => (checker string?)))
 
+  (testing "String literals"
     (fact "Only returns members of String for the very short \".g\" query"
       (src/members-candidates ".g" (-ns) (ctx/cache-context
                                           "(__prefix__ \"\")"))
       =>
       (just [{:candidate ".getChars", :type :method}
              {:candidate ".getBytes", :type :method}]
-        :in-any-order))))
+        :in-any-order))
+    
+    (fact "A docstring is offered for the previous query"
+      (src/members-doc ".codePointBefore" (-ns))
+      => (checker string?))))

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -1,5 +1,6 @@
 (ns compliment.sources.t-class-members
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [compliment.context :as ctx]
             [compliment.sources.class-members :as src]
             [compliment.t-helpers :refer :all]
@@ -106,7 +107,6 @@
     => (contains #{{:candidate ".put", :type :method}
                    {:candidate ".putAll", :type :method}} :gaps-ok))
 
-
   (fact "if context is provided and the first arg is a symbol with type tag
   (either immediate or anywhere in the local scope)"
     (strip-tags (src/members-candidates ".sta" (-ns) nil))
@@ -208,27 +208,38 @@
   (fact "static class members have docs"
     (src/static-member-doc "Integer/parseInt" (-ns)) => (checker string?)))
 
+(def java-version (-> (System/getProperty "java.version")
+                      (str/split #"\.")
+                      first
+                      read-string))
+
 (deftest literals-inference-test
-  (fact "Has around 19 candidates (give or take, varies per JDK),
+  (testing "Vector literals"
+    (let [candidates-count (count (src/members-candidates "." (-ns) (ctx/cache-context
+                                                                     "(__prefix__ [])")))
+          {:keys [major minor]} *clojure-version*
+          expected (if (and (= 1 major)
+                            (< minor 12))
+                     18
+                     19)]
+      (fact "Has around 19 candidates (give or take, varies per *clojure-version*),
 which indicates that the members are an exact match against the class of `[]`"
-    (let [c (count (src/members-candidates "." (-ns) (ctx/cache-context
-                                                      "(__prefix__ [])")))]
-      (< 17 c 21))
-    =>
-    truthy)
+        candidates-count => expected))
 
+    (fact "A docstring is offered for the previous query"
+      (src/members-doc ".assocN" (-ns)) => (checker string?)))
 
-  (fact "A docstring is offered for the previous query"
-    (src/members-doc ".assocN" (-ns)) => (checker string?))
-
-  (fact "Has around 50 candidates (give or take, varies per JDK),
+  (testing "String literals"
+    (let [candidates-count (count (src/members-candidates "." (-ns) (ctx/cache-context
+                                                                     "(__prefix__ \"\")")))
+          expected (case java-version
+                     1 35
+                     11 43
+                     50)]
+      (fact "Has around 50 candidates (give or take, varies per JDK),
 which indicates that the members are an exact match against the class of `\"\"`"
-    (let [c (count (src/members-candidates "." (-ns) (ctx/cache-context
-                                                      "(__prefix__ \"\")")))]
-      (< 34 c 52))
-    =>
-    truthy)
+        candidates-count => expected))
 
-  (fact "A docstring is offered for the previous query"
-    (src/members-doc ".codePointBefore" (-ns))
-    => (checker string?)))
+    (fact "A docstring is offered for the previous query"
+      (src/members-doc ".codePointBefore" (-ns))
+      => (checker string?))))

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -207,3 +207,28 @@
 
   (fact "static class members have docs"
     (src/static-member-doc "Integer/parseInt" (-ns)) => (checker string?)))
+
+(deftest literals-inference-test
+  (fact "Has around 19 candidates (give or take, varies per JDK),
+which indicates that the members are an exact match against the class of `[]`"
+    (let [c (count (src/members-candidates "." (-ns) (ctx/cache-context
+                                                      "(__prefix__ [])")))]
+      (< 17 c 21))
+    =>
+    truthy)
+
+
+  (fact "A docstring is offered for the previous query"
+    (src/members-doc ".assocN" (-ns)) => (checker string?))
+
+  (fact "Has around 50 candidates (give or take, varies per JDK),
+which indicates that the members are an exact match against the class of `\"\"`"
+    (let [c (count (src/members-candidates "." (-ns) (ctx/cache-context
+                                                      "(__prefix__ \"\")")))]
+      (< 34 c 52))
+    =>
+    truthy)
+
+  (fact "A docstring is offered for the previous query"
+    (src/members-doc ".codePointBefore" (-ns))
+    => (checker string?)))

--- a/test/compliment/sources/t_local_bindings.clj
+++ b/test/compliment/sources/t_local_bindings.clj
@@ -33,7 +33,19 @@
     (map (comp :tag meta)
          (src/bindings-from-context (ctx/parse-context '(let [a (string/trim "a")] __prefix__))
                                     (-ns)))
-    => (just [`String])))
+    => (just [`String]))
+
+  (fact "The class of a given binding can be identified by the class of a string literal"
+    (map (comp :tag meta)
+         (src/bindings-from-context (ctx/parse-context '(let [a ""] __prefix__))
+                                    (-ns)))
+    => (just [`String]))
+
+  (fact "The class of a given binding can be identified by the class of a vector literal"
+    (map (comp :tag meta)
+         (src/bindings-from-context (ctx/parse-context '(let [a []] __prefix__))
+                                    (-ns)))
+    => (just ['clojure.lang.PersistentVector])))
 
 (deftest local-bindings
   (defmacro ^{:completion/locals :let} like-let [& _])


### PR DESCRIPTION
Fixes https://github.com/alexander-yakushev/compliment/issues/106

Hopefully the inclusion of colls won't be a nuisance - as you can see, luckily it turned out to be a minimal addition.

Most pragmatically, it would be used in https://github.com/clojure-emacs/cider-nrepl/issues/812 for instance.

Cheers - V