### PR TITLE
[sources] Add support for candidate priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [cider#3792](https://github.com/clojure-emacs/cider/issues/3792): Don't fail
   if context macroexpansion throws an exception.
+- [#122](https://github.com/alexander-yakushev/compliment/pull/122): Introduce
+  sorting based on candidate priorities.
 - [#121](https://github.com/alexander-yakushev/compliment/pull/121): Remove
   deprecated `:plain-candidates` flag.
 

--- a/src/compliment/core.clj
+++ b/src/compliment/core.clj
@@ -20,16 +20,6 @@
             [clojure.string :refer [join]])
   (:import java.util.Comparator))
 
-(def ^:private by-length-comparator
-  "Sorts list of strings by their length first, and then alphabetically if length
-  is equal."
-  (reify Comparator
-    (compare [_ s1 s2]
-      (let [res (Integer/compare (.length ^String s1) (.length ^String s2))]
-        (if (zero? res)
-          (.compareTo ^String s1 s2)
-          res)))))
-
 (defn ensure-ns
   "Takes either a namespace object or a symbol and returns the corresponding
   namespace if it exists, otherwise returns `user` namespace."
@@ -64,11 +54,8 @@
                                  (if sources
                                    (all-sources sources)
                                    (all-sources)))
-             candidates (into [] (comp (map (fn [f] (f prefix nspc ctx))) cat) candidate-fns)
-             sorted-cands (if (= sort-order :by-name)
-                            (sort-by :candidate candidates)
-                            (sort-by :candidate by-length-comparator candidates))]
-         sorted-cands)))))
+             candidates (into [] (comp (map (fn [f] (f prefix nspc ctx))) cat) candidate-fns)]
+         (compliment.sources/sort-candidates candidates sort-order))))))
 
 ^{:lite nil}
 (defn documentation

--- a/src/compliment/sources.clj
+++ b/src/compliment/sources.clj
@@ -1,5 +1,6 @@
 (ns compliment.sources
-  "Tools for defining sources for the completion.")
+  "Tools for defining sources for the completion."
+  (:import java.util.Comparator))
 
 (def ^:private sources "Stores defined sources." (atom {}))
 
@@ -17,3 +18,44 @@
   [name & {:keys [candidates doc] :as kw-args}]
   {:pre [^{:lite 'candidates} (and candidates doc)]}
   (swap! sources assoc name (assoc kw-args :enabled true)))
+
+;;;; Candidate sorting
+
+(defmacro ^:private first-non-zero [& vals]
+  (let [[v & rst] vals]
+    (if (seq rst)
+      `(let [v# ~v]
+         (if (zero? v#)
+           (first-non-zero ~@rst)
+           v#))
+      v)))
+
+(def ^:private by-name-comparator
+  "Sorts list of candidates by their priority first and then alphabetically."
+  (reify Comparator
+    (compare [_ c1 c2]
+      (let [^String s1 (:candidate c1)
+            ^String s2 (:candidate c2)]
+        ;; Treat nil priority as very high - we want nils at the end of the list.
+        (first-non-zero (Integer/compare (:priority c1 999) (:priority c2 999))
+                        (.compareTo ^String s1 s2))))))
+
+(def ^:private by-length-comparator
+  "Sorts list of candidates by their priority first, then by length of candidate,
+  and then alphabetically."
+  (reify Comparator
+    (compare [_ c1 c2]
+      (let [^String s1 (:candidate c1)
+            ^String s2 (:candidate c2)]
+        ;; Treat nil priority as very high - we want nils at the end of the list.
+        (first-non-zero (Integer/compare (:priority c1 999) (:priority c2 999))
+                        (Integer/compare (.length s1) (.length s2))
+                        (.compareTo ^String s1 s2))))))
+
+(defn sort-candidates
+  "Sort `candidates` according to the provided `sort-order` keyword."
+  [candidates sort-order]
+  (sort (case sort-order
+          :by-name by-name-comparator
+          :by-length by-length-comparator)
+        candidates))

--- a/src/compliment/sources/class_members.clj
+++ b/src/compliment/sources/class_members.clj
@@ -7,6 +7,8 @@
                                                 resolve-class]])
   (:import [java.lang.reflect Field Member Method Modifier Constructor Executable]))
 
+(def ^:private base-priority 40)
+
 (defn- clojure-1-12+? []
   (or (> (:major *clojure-version*) 1)
       (>= (:minor *clojure-version*) 12)))
@@ -174,7 +176,10 @@
                       (str "." member-name))
          :type (cond exact-class? (first (:types (meta members)))
                      (instance? Method (first members)) :method
-                     :else :field)}))))
+                     :else :field)
+         ;; Assign lower (bigger number) priority to non-static members so that
+         ;; static members are shown first when qualified.
+         :priority (+ base-priority 1)}))))
 
 ;; ### Member documentation
 
@@ -292,7 +297,8 @@
           {:candidate (str cl-name "/" member-name)
            :type (cond (instance? Constructor (first members)) :constructor
                        (instance? Method (first members)) :static-method
-                       :else :static-field)})))))
+                       :else :static-field)
+           :priority base-priority})))))
 
 ^{:lite nil}
 (defn resolve-static-members

--- a/test/compliment/sources/t_class_members.clj
+++ b/test/compliment/sources/t_class_members.clj
@@ -267,6 +267,15 @@
   (testing "static class members have docs"
     (is? string? (src/static-member-doc "Integer/parseInt" (-ns)))))
 
+(when (#'src/clojure-1-12+?)
+  (deftest priority-test
+    (testing "static members are prioritized over non-static members"
+      (is? (mc/embeds [{:candidate "String/valueOf", :type :static-method, :priority 40}
+                       {:candidate "String/CASE_INSENSITIVE_ORDER", :type :static-field, :priority 40}
+                       {:candidate "String/.getBytes", :type :method, :priority 41}])
+           (concat (src/static-members-candidates "String/" (-ns) nil)
+                   (src/members-candidates "String/" (-ns) nil))))))
+
 (deftest literals-inference-test
   (testing "Vector literals"
     (testing "Only returns members of clojure.lang.PersistentVector for the very short \".s\" query"

--- a/test/compliment/sources/t_namespaces.clj
+++ b/test/compliment/sources/t_namespaces.clj
@@ -50,6 +50,11 @@
     (is? (mc/embeds ["c.str"])
          (strip-tags (src/candidates "c.st" (-ns) nil))))
 
+  (testing "priorities"
+    (is? (mc/embeds [{:candidate "compliment.core", :type :namespace, :file "compliment/core.clj", :priority 51}
+                     {:candidate "clojure.core", :type :namespace, :file "clojure/core.clj", :priority 50}])
+         (src/candidates "c" (-ns) nil)))
+
   (testing "namespaces have documentation"
     (is? string? (src/doc "clojure.core" (-ns)))
     (is? string? (src/doc "utils" (-ns)))

--- a/test/compliment/sources/t_vars.clj
+++ b/test/compliment/sources/t_vars.clj
@@ -136,6 +136,15 @@
                                                 (:require [clojure.string
                                                            :refer [__prefix__]])))))))
 
+  (testing "priorities"
+    (testing "first namespace's own vars, then clojure vars, then the rest"
+      (refer 'compliment.context :only '[cache-context])
+      (def catastrophic 1)
+      (is? (mc/embeds [{:candidate "catastrophic", :ns "compliment.sources.t-vars", :priority 30}
+                       {:candidate "cat", :ns "clojure.core", :priority 31}
+                       {:candidate "cache-context", :ns "compliment.context", :priority 32}])
+           (src/candidates "ca" (-ns) nil))))
+
   (testing "vars have documentation"
     (is? string? (src/doc "map" (-ns)))
     (is? string? (src/doc "clojure.core/map" (-ns)))

--- a/test/compliment/t_helpers.clj
+++ b/test/compliment/t_helpers.clj
@@ -10,3 +10,6 @@
 
 (defmacro is? [expected actual]
   `(is (~'match? ~expected ~actual)))
+
+(def jdk11+? (try (resolve 'java.lang.Runtime$Version)
+                  (catch Exception _)))


### PR DESCRIPTION
This feature allows sources to influence the final candidate order within the same source or across sources.