### PR TITLE
[c.s.keywords] Append / to ::ns-alias/ completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### master (unreleased)
 
+- [#126](https://github.com/alexander-yakushev/compliment/pull/126): Append `/`
+  when completing aliases in keywords.
+
 ### 0.7.0 (2025-03-25)
 
 - [cider#3792](https://github.com/clojure-emacs/cider/issues/3792): Don't fail

--- a/src/compliment/sources/keywords.clj
+++ b/src/compliment/sources/keywords.clj
@@ -32,7 +32,7 @@
     (for [[alias _] (ns-aliases ns)
           :let [aname (name alias)]
           :when (.startsWith aname prefix)]
-      (tagged-candidate (str "::" aname)))))
+      (tagged-candidate (str "::" aname "/")))))
 
 (defn aliased-candidates
   "Returns a list of alias-qualified double-colon keywords (like ::str/foo),
@@ -53,9 +53,10 @@
     (cond (and double-colon? has-slash?) (aliased-candidates prefix ns)
           double-colon? (concat (qualified-candidates prefix ns)
                                 (namespace-alias-candidates prefix ns))
-          single-colon? (for [[kw _] @keywords-table
-                              :when (.startsWith (str kw) (subs prefix 1))]
-                          (tagged-candidate (str ":" kw))))))
+          single-colon? (let [prefix (subs prefix 1)]
+                          (for [[kw _] @keywords-table
+                                :when (.startsWith (str kw) prefix)]
+                            (tagged-candidate (str ":" kw)))))))
 
 ^{:lite '(defsource :compliment.lite/keywords :candidates #'keyword-candidates)}
 (defsource ::keywords

--- a/test/compliment/sources/t_keywords.clj
+++ b/test/compliment/sources/t_keywords.clj
@@ -30,7 +30,7 @@
          (strip-tags (src/candidates "::core/ali" (find-ns 'compliment.sources.t-keywords) nil))))
 
   (testing "namespace aliases are completed when double colon"
-    (is? ["::src"]
+    (is? ["::src/"]
          (strip-tags (src/candidates "::s" (find-ns 'compliment.sources.t-keywords) nil))))
 
   (testing "keyword candidates have a special tag"


### PR DESCRIPTION
E.g. if you have `(require '[foo.core :as foo])`, then:
```clj
::f█ 
=> 
::foo/
```